### PR TITLE
Spotify-only rework: account selection, status/setup CLI, ~/.tapdeck config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           deno-version: v2.x
       - name: Compile binaries
         run: |
-          flags="--allow-ffi --allow-net --allow-read --allow-env=PCSC_LIB"
+          flags="--allow-ffi --allow-net --allow-read --allow-write --allow-run=pm2 --allow-env=PCSC_LIB,HOME"
           deno compile --target aarch64-unknown-linux-gnu $flags -o tapdeck-linux-arm64 index.ts
           deno compile --target x86_64-unknown-linux-gnu $flags -o tapdeck-linux-x86_64 index.ts
       - name: Publish release

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["denoland.vscode-deno"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,21 @@
+{
+  "deno.enable": true,
+  "deno.lint": true,
+  "editor.defaultFormatter": "denoland.vscode-deno",
+  "editor.formatOnSave": true,
+  "[typescript]": {
+    "editor.defaultFormatter": "denoland.vscode-deno"
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "denoland.vscode-deno"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "denoland.vscode-deno"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "denoland.vscode-deno"
+  },
+  "[markdown]": {
+    "editor.defaultFormatter": "denoland.vscode-deno"
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,69 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+Tapdeck reads NFC tags from a PC/SC card reader (tested on the ACR122U) and plays the corresponding music on Sonos — tap a tag and the matching Spotify item plays (tapdeck is Spotify-only). It is a single self-contained Deno binary with **no native addons and no runtime dependencies** — the only `imports` in `deno.json` are dev-only (`@std/assert`, `@std/testing`). Both the NFC reader and the Sonos engine are implemented in-project. Keeping dependencies near zero is a core philosophy of this project.
+
+## Commands
+
+```bash
+deno task start     # run from source (FFI + net + read perms baked in)
+deno task test      # run all tests
+deno task compile   # build the self-contained ./tapdeck binary
+deno task lint
+deno task fmt
+deno check index.ts lib/   # type-check (what CI runs)
+```
+
+Run a single test file or filter by name:
+
+```bash
+deno test --allow-read --allow-net lib/sonos/__tests__/soap_test.ts
+deno test --allow-read --allow-net --filter "buildEnvelope"
+```
+
+CI (`.github/workflows/ci.yml`) runs, in order: `deno fmt --check`, `deno lint`, `deno check index.ts lib/`, then `deno task test`. Run these locally before pushing. Pushing a `v*` tag triggers `release.yml`, which cross-compiles Linux arm64 + x86_64 binaries and attaches them to a GitHub release.
+
+`deno fmt` config (in `deno.json`) is non-default: 100-col, single quotes, `proseWrap: preserve` (so Markdown is never hard-wrapped). `compilerOptions` enables `strict` **and** `noUncheckedIndexedAccess` — indexing an array yields `T | undefined`, which is why you'll see `!` assertions in the byte-parsing code in `lib/nfc`.
+
+## Runtime permissions
+
+`start`/`compile` bake in: `--allow-ffi` (load libpcsclite for the reader), `--allow-net` (Sonos over LAN), `--allow-read` (config file), `--allow-write` (the `setup` subcommand writes the config), `--allow-run=pm2` (setup's optional autostart registration), and `--allow-env=PCSC_LIB,HOME` (libpcsclite path + locating `~/.tapdeck/config.json`). The permission set is a superset across all subcommands; the reader loop itself doesn't write or spawn, but the single binary serves `setup` too. Tests need `--allow-read --allow-net --allow-env`.
+
+## CLI subcommands
+
+`index.ts` dispatches on `Deno.args[0]` before starting the reader, and **lazily imports** the reader/command modules only on the default path — so `status`/`setup` don't load the FFI layer or trigger `process_sonos_command`'s module-level settings load. `status [ip]` prints the connected IP, rooms (+IPs), and Spotify accounts — the pre-setup diagnostic. `setup [ip]` is interactive (`prompt()`/`confirm()`, so it needs a real TTY — they return null/false when stdin is piped): it picks a room and Spotify account, writes the config, and then offers to register with pm2 (`offerPm2` shells out to `pm2 jlist`/`start`/`save`, using `Deno.execPath()` as the start target). The bare `tapdeck` (reader) path first checks `hasUserConfig()` and, on a fresh install with no real config, runs `setup` instead of starting. Both subcommands take an optional seed-IP arg to skip discovery.
+
+## Architecture
+
+The flow is one line in `index.ts`: `startReader(onTag)` loops forever, and each scanned tag's text is handed to `processSonosCommand`. The two halves — reading tags and driving Sonos — are fully independent and meet only at that callback.
+
+Settings (`lib/settings.ts`) load from, in order: `usersettings.json` in the cwd (dev / beside-the-binary), then `~/.tapdeck/config.json` (where `setup` writes and an installed binary reads); with neither present, defaults apply and the bare-`tapdeck` path runs `setup`. `configFilePath()` is a pure function (takes `HOME`) so it's testable without env access.
+
+### NFC reader (`lib/nfc/`)
+
+- `pcsc.ts` — a hand-written PC/SC (winscard) binding to **libpcsclite via Deno FFI**. This is the part that replaces the old `nfc-pcsc` native addon (nan can't load under Deno). It encodes the pcsc-lite 64-bit Linux ABI directly: `DWORD`/handles are 8 bytes, the `SCARD_READERSTATE` struct is laid out by hand with explicit byte offsets, and blocking calls (`GetStatusChange`, `Connect`, `Transmit`) are declared `nonblocking` so they run off-thread and return Promises. If you touch this file, the offset/size comments are load-bearing — getting them wrong produces silent memory corruption, not errors.
+- `reader.ts` — the monitor loop. Waits for a reader to appear, then uses `waitForChange` to detect card insertion, reads NTAG user memory from page 4 via `FF B0` read APDUs until a full NDEF message is assembled, and invokes the callback. Heavy on retries by design: a card passes through transient unpowered/unresponsive states right after landing (`POWERING_UP` set in `pcsc.ts`), so `connectWithRetry` retries ~3.6s, and the whole read is retried up to 3× because cards power up slowly or shift mid-read. Don't "simplify" the retries away — they're fixes for real flakiness (see commits 9a5fb74, 4773c86, 4ec7091).
+- `ndef.ts` — minimal NDEF parsing, only the Text (`T`) and URI (`U`) records the jukebox uses. `extractNdefMessage` walks the TLV-framed tag memory for the NDEF TLV (0x03) and returns `null` when the message isn't fully read yet, which is the signal `reader.ts` uses to read another chunk.
+
+### Sonos engine (`lib/sonos/`)
+
+A small, dependency-free UPnP/SOAP client. `index.ts` is the only entry point the rest of the app imports; it lazily builds and **caches one `SonosSystem` per process** (`getEngine`) — the first tap pays the discovery cost, later taps reuse it. On bootstrap failure the cache is cleared so the next tap retries.
+
+- `discovery.ts` — SSDP multicast (`node:dgram`) to find any one ZonePlayer. Requires being on the same L2 network as the speakers; `sonos_seed_ip` in settings skips this entirely.
+- `system.ts` — owns discovery bootstrap, topology, the Spotify service-id lookup, and Spotify-account discovery. `refreshTopology` parses `GetZoneGroupState` into a `room name (lowercased) → group coordinator` map; `resolveRoom` returns the coordinator `Player` and refreshes topology once on a miss. `getSpotifyAccounts` mines favorites (`FV:2`, household-wide) and each room's queue (`Q:0`, per-coordinator) via ContentDirectory `Browse` to recover the linked Spotify accounts' serial numbers, for `status`/`setup`; `getFavorites` is kept solely for that.
+- `player.ts` — a coordinator you send transport/rendering SOAP actions to. Note Sonos packs repeat+shuffle into one combined `PlayMode` string, so `setRepeat`/`setShuffle` read the current mode first and flip only their own dimension (`PLAYMODE` map).
+- `services/spotify.ts` — turns a `spotify:track|album|playlist:ID` URI into the Sonos-native `x-sonos-spotify:`/`x-rincon-cpcontainer:` URI plus DIDL metadata, then runs the play-now queue sequence. **tapdeck plays Spotify only** — there is no favorites/playlists path; `spotify_account_sn` selects which linked Spotify account.
+- `soap.ts` / `xml.ts` — SOAP transport over the runtime's built-in `fetch`, and small, dependency-free XML helpers (no XML library). Tag/attr extraction is regex-based; `encodeEntities`/`decodeEntities` hand-roll the five XML entities plus all numeric (decimal & hex) character references. `decodeEntities` may need to run **twice**: Sonos double-encodes nested DIDL (e.g. a Browse `<Result>` or a favorite's `<r:resMD>`).
+
+### Tag command dispatch (`lib/process_sonos_command.ts`)
+
+Classifies tag text by prefix — `spotify:`, `command:`, `room:` — and routes it; tapdeck is Spotify-only, so any other prefix is rejected with a message. `room:` is pure local state (no Sonos call). `command:` is a raw transport passthrough (`play`, `pause`, `volume/40`, `volume/+5`, `repeat/all`, `shuffle/on`, …) that skips the pre-play reset. A `spotify:` tag runs a best-effort pre-play reset (repeat/shuffle/crossfade off — on by default, opt out in config — plus clear queue), each step wrapped in `tryReset` so a Sonos rejection is logged and skipped rather than aborting playback, then bumps a near-muted speaker to an audible floor before enqueuing via `spotify.now`.
+
+Settings are read once at module load. Defaults for the reset flags, `min_volume`, and `spotify_account_sn` live in the code, so tapdeck runs with no config at all; `usersettings.json` is gitignored, and `tapdeck setup` writes `~/.tapdeck/config.json`.
+
+### Testing conventions
+
+Tests live in `__tests__/` dirs next to the code, named `*_test.ts`, using `Deno.test` + `@std/assert`. The engine is **dependency-injected** into `process_sonos_command` (the `CommandDeps` parameter, defaulting to the real `getEngine`/`spotify`) so command-dispatch logic is tested with fakes — there's no module-mocking framework. Tests cover pure logic (NDEF parsing, XML helpers, SOAP body building, Spotify URI construction, command routing); the FFI reader and live network calls are not unit-tested.

--- a/README.md
+++ b/README.md
@@ -1,53 +1,56 @@
+# Tapdeck
+
 [![CI](https://github.com/codybrom/tapdeck/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/codybrom/tapdeck/actions/workflows/ci.yml)
 
-# tapdeck
+## Getting Started
 
-tapdeck lets you tap an NFC tag to play Spotify, a Sonos favorite, or a playlist on your Sonos — like dropping a record on a deck. Stick a cheap NFC sticker on a card (or a coaster, or a printed photo, or really anything), program it with what you want to hear, and tap it on a card reader to play. It ships as a single self-contained binary that reads your NFC reader and talks to your Sonos speakers directly over the local network, so there's no cloud service, no separate API server to babysit, no account credentials to configure, and no runtime to install.
+There's something that just feels right about using your hands and physical objects to play music. Tapdeck was built to make the software side of reading NFC tags and play Spotify to a Sonos system as easy as possible. A self-contained binary interfaces with a USB NFC reader to control Sonos speakers over the local network without API keys or logins.
 
-## About
+### Items You'll Need
 
-There's a genuinely nice aesthetic to controlling a streaming service with physical media, and honestly making the cards is half the fun — NTAG213 stickers run well under $15 for fifty, so you can make a big stack of them and decorate them however you like. It's also a hit with kids: little ones who can't read yet can absolutely learn that tapping the dinosaur card plays the dinosaur songs.
+- A Raspberry Pi (or other always-on Linux machine)
+- A USB ACR122U RFID/NFC reader
+- Programmable NFC tags, like cheap NTAG213 stickers
+- A smartphone to program the tags
 
-tapdeck is tested with the ACR122U, an inexpensive and widely available USB reader. The ACR122U has a bit of a reputation for being awkward with general-purpose NFC libraries, but it's a perfectly good PC/SC smart-card reader, and PC/SC is all tapdeck needs — so it works reliably here, and should work with any other PC/SC-compatible reader too.
+Tapdeck was specifically built for use with the ACR122U because it is an inexpensive and widely available USB reader. You can find it online from a variety of sellers, sometimes with included tags.
 
-## Thanks
+### Setting up the NFC reader
 
-tapdeck began life as a fork of Ryan Olf's [node-sonos-nfc](https://github.com/ryanolf/node-sonos-nfc), and a big thank-you goes to Ryan for the original version that got this whole thing rolling. It has since been rewritten from the ground up: where the original leaned on a native Node addon to read the card reader and an external HTTP API to control Sonos, tapdeck now reads the reader directly through libpcsclite via FFI with no native addon at all, and drives Sonos with its own small, dependency-free UPnP engine. The original tap-a-card-to-play idea traces back to hankhank10's [Sonos Vinyl Emulator](https://github.com/hankhank10/vinylemulator), which is well worth a look.
+On your Raspberry Pi (or any Debian/Ubuntu machine), install the reader's driver, middleware and daemon:
 
-## What you'll need
-
-You'll need a PC/SC card reader — an ACR122U is the safe bet — plugged into any always-on computer that sits on the same network as your Sonos. People often use a Raspberry Pi for this, but any spare machine will do. You'll also want a handful of NFC tags; the cheap NTAG213 stickers are perfect.
-
-# Installing
-
-## Setting up the reader
-
-On a Linux box (Ubuntu, Debian, or Raspberry Pi OS), install the reader driver along with the PC/SC library and daemon:
-
-```
-$ sudo apt install libacsccid1 libpcsclite1 pcscd
+```bash
+sudo apt install libacsccid1 libpcsclite1 pcscd
 ```
 
-Linux will sometimes try to claim the ACR122U with its own kernel NFC modules, which gets in the way, so blacklist them and reboot to be safe:
+Linux will sometimes try to claim the ACR122U with its own kernel NFC modules, so before going any further, blacklist them and reboot:
 
-```
-$ printf '%s\n' 'pn533' 'pn533_usb' 'nfc' | sudo tee /etc/modprobe.d/blacklist-nfc.conf
-$ sudo reboot
-```
-
-## Getting tapdeck
-
-Grab the binary for your platform from the [Releases](https://github.com/codybrom/tapdeck/releases) page and mark it executable:
-
-```
-$ chmod +x tapdeck
+```bash
+printf '%s\n' 'pn533' 'pn533_usb' 'nfc' | sudo tee /etc/modprobe.d/blacklist-nfc.conf
+sudo reboot
 ```
 
-That's the whole install — the binary is self-contained, loads libpcsclite at runtime, and talks to Sonos over the network, so there's nothing else to set up. If you'd rather build it yourself, or you're on a platform without a prebuilt binary, see [Development](#development) below.
+### Installing Tapdeck
 
-## Configuring
+Grab the binary for your platform from [Releases](https://github.com/codybrom/tapdeck/releases), make it executable, and move it onto your `PATH`:
 
-Drop a usersettings.json next to the binary (start from the included example file) and, at the very least, set the room you want your cards to control. A full settings file looks like this:
+| Device Type                                  | Filename               |
+| -------------------------------------------- | ---------------------- |
+| Raspberry Pi or other Arm-based Linux device | `tapdeck-linux-arm64`  |
+| Intel/AMD-based Linux devices                | `tapdeck-linux-x86_64` |
+
+```bash
+chmod +x tapdeck-linux-arm64
+sudo mv tapdeck-linux-arm64 /usr/local/bin/tapdeck
+```
+
+For other platforms, or to build it yourself, see [Development](#development).
+
+### Configuring
+
+Run `tapdeck setup`. It finds your system, asks which room and Spotify account you want to use, and writes your config to `~/.tapdeck/config.json`.
+
+#### Example Config
 
 ```json
 {
@@ -56,52 +59,84 @@ Drop a usersettings.json next to the binary (start from the included example fil
   "reset_repeat": true,
   "reset_shuffle": true,
   "reset_crossfade": true,
-  "min_volume": 10
+  "min_volume": 10,
+  "spotify_account_sn": 1
 }
 ```
 
-The room name is really the only thing you have to set, and it's matched without worrying about capitalization. If multicast discovery is blocked on your network and tapdeck can't find your speakers on its own, fill in a seed IP — the address of any one Sonos player — and it'll bootstrap from there. The three reset options control whether tapdeck turns off repeat, shuffle, and crossfade before it queues up new music, which it does by default so that a fresh tap behaves predictably. And the minimum volume is a small kindness: if you tap a music card while the speaker is turned almost all the way down, tapdeck nudges it back up so a card never seems to do nothing.
+### Troubleshooting Setup
 
-## Running it
+If you have any issues, you can run `tapdeck status` to get a readout of what tapdeck can see on your system.
 
-```
-$ ./tapdeck
-```
+```bash
+$ tapdeck status
+Connected to Sonos at 192.168.0.195
 
-It needs to be on the same network as your speakers, since it discovers them with UDP multicast. Tap a card and the matching music plays.
+Rooms — set "sonos_room" to the one your cards should control:
+  Kitchen              192.168.0.96
+  Living Room          192.168.0.153
+  Office               192.168.0.195
 
-# What you can put on a card
-
-The text you write to a tag is what decides what it does. A Spotify URI — something like spotify:track:…, spotify:album:…, or spotify:playlist:… — plays that item from Spotify. A tag that reads "favorite:" followed by the name of one of your saved Sonos favorites plays that favorite, and since favorites can point at any service you've connected in the Sonos app, that's also how you reach Apple Music, Amazon, radio stations, and the rest — none of those are built in on their own, so the trick is to save them as Sonos favorites. A "playlist:" tag followed by a Sonos playlist name plays that playlist, and a "room:" tag followed by a room name changes which room your taps control from then on. Finally, anything that starts with "command:" is passed straight through as a transport command — play, pause, next, previous, volume/40, volume/+5, repeat/all, shuffle/on, crossfade/off, mute, clearqueue, and so on.
-
-# Keeping it running
-
-For day-to-day use you'll want tapdeck under a process supervisor so it starts at boot and comes back if it ever exits. pm2 is an easy option:
-
-```
-$ pm2 start ./tapdeck --name tapdeck
-$ pm2 save
-$ pm2 startup
+Spotify accounts — set "spotify_account_sn" to the one you want:
+  spotify_account_sn: 2 [token 0]
+      • Songs
 ```
 
-Run the command that pm2 startup prints to wire it into your init system. systemd works just as well if you'd rather point a unit file at the binary.
+- Only `sonos_room` is required for Tapdeck to work. It is matched case-insensitively.
+- If Tapdeck can't automatically discover your speakers, you can use the `sonos_seed_ip` on the config to bootstrap discovery with a known IP of a speaker. Sleeping speakers may not appear if something hasn't been played recently.
+- The `reset_*` flags clear repeat, shuffle, and crossfade before each tap so playback starts predictably, and `min_volume` raises a near-silent speaker so a tap is never inaudible.
+- `spotify_account_sn` chooses which linked Spotify account to play from. If you have more than one Spotify account tied to your Sonos system and are having trouble setting the right account, try playing from the account you wish to use using the Sonos app and then check the value in `tapdeck status`.
 
-# Programming cards
+## Running Tapdeck
 
-Each card holds an NDEF message, and tapdeck reads the first text or URI record off it and treats that as the tag text described above. This matches the card format used by [Sonos Vinyl Emulator](https://github.com/hankhank10/vinylemulator), so cards made for that will work here unchanged.
+Make sure your reader is plugged in and active, then run `tapdeck` and tap a tag. You will most likely hear the reader beep or see the reader's LED turn green when it has successfully detected a tag. If you have issues with tag reads, please note that a successful read may require hovering over the reader for about 1-2 seconds after it beeps/LED turns green.
 
-The simplest way to write cards is a phone app — [NFC Tools](https://www.wakdev.com/en/apps/nfc-tools-pc-mac.html) on iOS or Android does the job nicely. Write a single text or URI record containing whatever you want, like spotify:album:… or favorite:Coffee House. If a tag is brand new, format it for NDEF first (NXP TagWriter is handy for that) and then write your record.
+### Running Tapdeck at Boot / In the Background
 
-# Development
+To start it at boot and bring it back if it exits, run it under a supervisor like pm2:
 
-tapdeck is written in TypeScript and runs on [Deno](https://deno.com), which you only need if you want to build it or hack on it — running a release binary needs nothing at all. With Deno installed, the usual tasks are there:
-
+```bash
+pm2 start tapdeck --name tapdeck
+pm2 save
+pm2 startup
 ```
-$ deno task start     # run from source
-$ deno task test      # run the tests
-$ deno task lint
-$ deno task fmt
-$ deno task compile   # build the self-contained ./tapdeck binary
+
+## Programming Tags
+
+Tapdeck reads the first text or URI record on a tag and acts on it. To get a Spotify item's ID, copy its share URL and take the part before any query params (i.e. ignore anything after the `?`, like `?si=6f54337b83214964`):
+
+```txt
+https://open.spotify.com/track/4cOdK2wGLETKBW3PvgPWqT?si=6f54337b83214964 -> spotify:track:4cOdK2wGLETKBW3PvgPWqT
 ```
 
-The NFC layer speaks to libpcsclite directly through Deno's FFI, so there's no native addon to compile, and the Sonos engine is a small, dependency-free UPnP/SOAP client. Running from source needs three permissions, all baked into the start task: FFI access for the reader, network access for Sonos, and read access for your settings file.
+- `spotify:<type>:<id>` - Spotify media items
+  - `spotify:track:<id>` - Single song
+  - `spotify:album:<id>` - Single album
+  - `spotify:playlist:<id>` — Spotify Playlist (account must have access)
+- `room:<name>` — Change which room your taps control from then on.
+- `command:<verb>` — transport commands
+  - `command:play`
+  - `command:pause`
+  - `command:next`
+  - `command:previous`
+  - `command:volume/40`
+  - `command:volume/+5`
+  - `command:repeat/all`
+  - `command:shuffle/on`
+  - `command:crossfade/off`
+  - `command:mute`
+  - `command:clearqueue`
+
+This is the same card format used by [Sonos Vinyl Emulator](https://github.com/hankhank10/vinylemulator). Write tags with a phone app like [NFC Tools](https://www.wakdev.com/en/apps/nfc-tools-pc-mac.html): a single text or URI record holding the text above. Format brand-new tags for NDEF first (NXP TagWriter handles that).
+
+## Development
+
+Tapdeck is written in TypeScript and runs on [Deno](https://deno.com). From source it needs FFI access (the reader), network access (Sonos), read and write access (the config file `setup` creates), permission to run `pm2` (setup's optional autostart step) and env access, all of which are baked into the start task in `deno.json` (run it with `deno task start`).
+
+## Acknowledgements
+
+Tapdeck started as a fork of Ryan Olf's [node-sonos-nfc](https://github.com/ryanolf/node-sonos-nfc), which itself traces back to hankhank10's [Sonos Vinyl Emulator](https://github.com/hankhank10/vinylemulator). Major thanks to both, and to the maintainers of the open-source PC/SC and ACR122U tooling.
+
+## License
+
+[MIT License](LICENSE).

--- a/deno.json
+++ b/deno.json
@@ -1,9 +1,9 @@
 {
   "version": "1.0.0",
   "tasks": {
-    "start": "deno run --allow-ffi --allow-net --allow-read --allow-env=PCSC_LIB index.ts",
-    "compile": "deno compile --allow-ffi --allow-net --allow-read --allow-env=PCSC_LIB -o tapdeck index.ts",
-    "test": "deno test --allow-read --allow-net",
+    "start": "deno run --allow-ffi --allow-net --allow-read --allow-write --allow-run=pm2 --allow-env=PCSC_LIB,HOME index.ts",
+    "compile": "deno compile --allow-ffi --allow-net --allow-read --allow-write --allow-run=pm2 --allow-env=PCSC_LIB,HOME -o tapdeck index.ts",
+    "test": "deno test --allow-read --allow-net --allow-env",
     "lint": "deno lint",
     "fmt": "deno fmt"
   },
@@ -21,6 +21,10 @@
     "proseWrap": "preserve"
   },
   "lint": {
-    "rules": { "tags": ["recommended"] }
+    "rules": {
+      "tags": [
+        "recommended"
+      ]
+    }
   }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -3,23 +3,51 @@
   "specifiers": {
     "jsr:@std/assert@^1.0.13": "1.0.19",
     "jsr:@std/assert@^1.0.19": "1.0.19",
+    "jsr:@std/async@^1.4.0": "1.4.0",
+    "jsr:@std/data-structures@^1.1.0": "1.1.0",
+    "jsr:@std/fs@^1.0.24": "1.0.24",
     "jsr:@std/internal@^1.0.12": "1.0.14",
+    "jsr:@std/internal@^1.0.14": "1.0.14",
+    "jsr:@std/path@^1.1.5": "1.1.5",
     "jsr:@std/testing@^1.0.9": "1.0.19"
   },
   "jsr": {
     "@std/assert@1.0.19": {
       "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
       "dependencies": [
-        "jsr:@std/internal"
+        "jsr:@std/internal@^1.0.12"
+      ]
+    },
+    "@std/async@1.4.0": {
+      "integrity": "4d70b008634f571cff9b554090d628c76141c32613aae0ff283fd5fa23d0c379"
+    },
+    "@std/data-structures@1.1.0": {
+      "integrity": "c35ae4ad5d8e41a38573c2fe3e19b18ea2505f63cfea201edcb8720aca1f7f58"
+    },
+    "@std/fs@1.0.24": {
+      "integrity": "f3061b45b81673a2bece689da041df32d174be064c89eb6397fb5718d3fb7877",
+      "dependencies": [
+        "jsr:@std/path"
       ]
     },
     "@std/internal@1.0.14": {
       "integrity": "291516b3d4c35024d6ffbc0a9df5bf4c64116e05b50012cf846710152d2ffdf7"
     },
+    "@std/path@1.1.5": {
+      "integrity": "ccea00982ea28c36becaf6e62f855406c76a8c32d462f66f415bbb7d83a271bc",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.14"
+      ]
+    },
     "@std/testing@1.0.19": {
       "integrity": "f4236172365b216728dc3cc8b5e80a9f4c33083d1e4ede7613d5b25b4014898e",
       "dependencies": [
-        "jsr:@std/assert@^1.0.19"
+        "jsr:@std/assert@^1.0.19",
+        "jsr:@std/async",
+        "jsr:@std/data-structures",
+        "jsr:@std/fs",
+        "jsr:@std/internal@^1.0.14",
+        "jsr:@std/path"
       ]
     }
   },

--- a/index.ts
+++ b/index.ts
@@ -2,13 +2,154 @@
 // The FFI reader (lib/nfc) replaces nfc-pcsc; the Sonos engine (lib/sonos)
 // talks to the speakers directly over the LAN.
 
-import { startReader } from './lib/nfc/reader.ts';
-import process_sonos_command from './lib/process_sonos_command.ts';
+import { getEngine } from './lib/sonos/index.ts';
+import type { SonosSystem } from './lib/sonos/index.ts';
+import {
+  DEFAULT_SETTINGS,
+  hasUserConfig,
+  loadSettings,
+  type Settings,
+  userConfigPath,
+} from './lib/settings.ts';
+import { offerPm2 } from './lib/pm2.ts';
 
-await startReader(async (text) => {
+// A seed IP for the status/setup subcommands: an explicit `<ip>` arg wins,
+// otherwise fall back to the configured one. Lazy so the reader path never
+// triggers it.
+const seedArg = () => Deno.args[1] ?? loadSettings().sonos_seed_ip;
+
+// `tapdeck status [ip]` — the one call to run before (or while) configuring.
+// It finds your system and prints everything the config needs: the rooms you can
+// target, their IPs (proof the network works + a seed_ip candidate), and the
+// Spotify accounts in use. Anything else falls through to the reader.
+if (Deno.args[0] === 'status') {
+  await printStatus(seedArg());
+  Deno.exit(0);
+}
+
+// `tapdeck setup [ip]` — interactively discover the system, ask which room and
+// Spotify account to use, and write the config to the standard per-user
+// location, then exit.
+if (Deno.args[0] === 'setup') {
+  await runSetup(seedArg());
+  Deno.exit(0);
+}
+
+// First run with no config — guide the user straight into setup instead of
+// silently falling back to defaults.
+if (!hasUserConfig()) {
+  console.log("No tapdeck config found yet. Let's set one up.\n");
+  await runSetup(undefined);
+  Deno.exit(0);
+}
+
+// Default: run the reader loop. Imported lazily so the status/setup subcommands
+// don't pull in the FFI reader or trigger the command module's settings load.
+const { startReader } = await import('./lib/nfc/reader.ts');
+const { default: processSonosCommand } = await import(
+  './lib/process_sonos_command.ts'
+);
+// The reader loop already aggregates callback failures (logs and continues to
+// the next tap), so no try/catch is needed here.
+await startReader((text) => processSonosCommand(text));
+
+// Print a numbered menu and read the user's choice (1-based). Returns the chosen
+// item, or null on an out-of-range / non-numeric / non-TTY answer.
+function chooseFromList<T>(items: T[], render: (item: T) => string): T | null {
+  items.forEach((item, i) => console.log(`  ${i + 1}) ${render(item)}`));
+  const idx = Number(prompt(`Enter a number [1-${items.length}]:`)) - 1;
+  return items[idx] ?? null;
+}
+
+// Connect to the Sonos system for a CLI subcommand, or exit with guidance.
+async function connect(seedIp: string | undefined, cmd: string): Promise<SonosSystem> {
   try {
-    await process_sonos_command(text);
+    return await getEngine(seedIp ? { seedIp } : {});
   } catch (err) {
-    console.error((err as Error).toString());
+    console.error(`Could not reach your Sonos system: ${(err as Error).message}`);
+    console.error(
+      'Make sure this machine is on the same network as your speakers. If ' +
+        `discovery is blocked, pass a player IP: tapdeck ${cmd} <ip>`,
+    );
+    Deno.exit(1);
   }
-});
+}
+
+async function printStatus(seedIp?: string): Promise<void> {
+  const system = await connect(seedIp, 'status');
+
+  console.log(`Connected to Sonos at ${system.connectedIp}`);
+  console.log(
+    '  (if auto-discovery ever fails, set this as "sonos_seed_ip" in usersettings.json)\n',
+  );
+
+  const rooms = system.listRooms();
+  console.log('Rooms — set "sonos_room" to the one your cards should control:');
+  for (const { name, ip } of rooms) {
+    console.log(`  ${name.padEnd(20)} ${ip}`);
+  }
+
+  const accounts = await system.getSpotifyAccounts();
+  console.log('\nSpotify accounts — set "spotify_account_sn" to the one you want:');
+  if (accounts.length === 0) {
+    console.log(
+      '  none found in your favorites or queues. With a single linked account ' +
+        'the default of 1 is usually right; otherwise play a Spotify track and re-run.',
+    );
+  } else {
+    for (const { token, sn, examples } of accounts) {
+      const label = sn === null
+        ? 'unknown (play a track from this account, then re-run)'
+        : String(sn);
+      console.log(`  spotify_account_sn: ${label}${token ? ` [token ${token}]` : ''}`);
+      for (const title of examples) console.log(`      • ${title}`);
+    }
+  }
+}
+
+async function runSetup(seedIp?: string): Promise<void> {
+  const system = await connect(seedIp, 'setup');
+  console.log(`Connected to Sonos at ${system.connectedIp}\n`);
+
+  // Pick a room.
+  const rooms = system.listRooms();
+  if (rooms.length === 0) {
+    console.error('No rooms found. Is this the right network?');
+    Deno.exit(1);
+  }
+  console.log('Which room should your cards control?');
+  const room = chooseFromList(rooms, (r) => `${r.name}  (${r.ip})`);
+  if (!room) {
+    console.error('Not a valid choice; nothing written.');
+    Deno.exit(1);
+  }
+
+  // Pick a Spotify account (default 1 when none is discoverable).
+  const known = (await system.getSpotifyAccounts()).filter((a) => a.sn !== null);
+  let accountSn = 1;
+  if (known.length === 1) {
+    accountSn = known[0]!.sn!;
+    console.log(`\nUsing Spotify account spotify_account_sn=${accountSn}.`);
+  } else if (known.length > 1) {
+    console.log('\nWhich Spotify account?');
+    const chosen = chooseFromList(known, (a) => `sn=${a.sn}  (e.g. ${a.examples[0] ?? '—'})`);
+    accountSn = chosen?.sn ?? 1;
+  } else {
+    console.log('\nNo Spotify account detected; defaulting spotify_account_sn=1.');
+  }
+
+  const settings: Settings = {
+    ...DEFAULT_SETTINGS,
+    sonos_room: room.name,
+    spotify_account_sn: accountSn,
+  };
+
+  const path = userConfigPath() ?? 'usersettings.json';
+  const slash = path.lastIndexOf('/');
+  if (slash > 0) await Deno.mkdir(path.slice(0, slash), { recursive: true });
+  await Deno.writeTextFile(path, JSON.stringify(settings, null, 2) + '\n');
+  console.log(`\nWrote ${path}`);
+
+  await offerPm2();
+  console.log('\nRun tapdeck (no arguments) to start reading cards.');
+}

--- a/lib/__tests__/process_sonos_command_test.ts
+++ b/lib/__tests__/process_sonos_command_test.ts
@@ -1,6 +1,6 @@
 import { assertEquals } from '@std/assert';
 import { assertSpyCallArgs, assertSpyCalls, type Spy, spy, stub } from '@std/testing/mock';
-import process_sonos_command, { type CommandDeps } from '../process_sonos_command.ts';
+import processSonosCommand, { type CommandDeps } from '../process_sonos_command.ts';
 
 function makeDeps(volume = 30) {
   const player = {
@@ -20,8 +20,6 @@ function makeDeps(volume = 30) {
   };
   const system = {
     resolveRoom: spy(() => Promise.resolve(player)),
-    playFavorite: spy(() => Promise.resolve('')),
-    playPlaylist: spy(() => Promise.resolve('')),
   };
   const spotifyNow = spy(() => Promise.resolve(''));
   const deps = {
@@ -33,44 +31,39 @@ function makeDeps(volume = 30) {
 
 function captureLogs(): { logs: string[]; restore: () => void } {
   const logs: string[] = [];
-  const s = stub(console, 'log', (...args: unknown[]) => void logs.push(args.join(' ')));
+  const s = stub(
+    console,
+    'log',
+    (...args: unknown[]) => void logs.push(args.join(' ')),
+  );
   return { logs, restore: () => s.restore() };
 }
 
-Deno.test('spotify tag plays via spotify.now after the reset sequence', async () => {
-  const { deps, player, system, spotifyNow } = makeDeps();
-  const { restore } = captureLogs();
-  await process_sonos_command('spotify:track:abc123', deps);
-  restore();
-  assertSpyCalls(system.resolveRoom as Spy, 1);
-  assertSpyCallArgs(player.setRepeat as Spy, 0, ['none']);
-  assertSpyCallArgs(player.setShuffle as Spy, 0, [false]);
-  assertSpyCallArgs(player.setCrossfade as Spy, 0, [false]);
-  assertSpyCalls(player.clearQueue as Spy, 1);
-  assertSpyCallArgs(spotifyNow as Spy, 0, [player, system, 'spotify:track:abc123']);
-});
-
-Deno.test('favorite tag plays the named favorite', async () => {
-  const { deps, player, system } = makeDeps();
-  const { restore } = captureLogs();
-  await process_sonos_command('favorite:Songs', deps);
-  restore();
-  assertSpyCalls(player.clearQueue as Spy, 1);
-  assertSpyCallArgs(system.playFavorite as Spy, 0, [player, 'Songs']);
-});
-
-Deno.test('playlist tag plays the named playlist (URL-decoded)', async () => {
-  const { deps, player, system } = makeDeps();
-  const { restore } = captureLogs();
-  await process_sonos_command('playlist:My%20Mix', deps);
-  restore();
-  assertSpyCallArgs(system.playPlaylist as Spy, 0, [player, 'My Mix']);
-});
+Deno.test(
+  'spotify tag plays via spotify.now after the reset sequence',
+  async () => {
+    const { deps, player, system, spotifyNow } = makeDeps();
+    const { restore } = captureLogs();
+    await processSonosCommand('spotify:track:abc123', deps);
+    restore();
+    assertSpyCalls(system.resolveRoom as Spy, 1);
+    assertSpyCallArgs(player.setRepeat as Spy, 0, ['none']);
+    assertSpyCallArgs(player.setShuffle as Spy, 0, [false]);
+    assertSpyCallArgs(player.setCrossfade as Spy, 0, [false]);
+    assertSpyCalls(player.clearQueue as Spy, 1);
+    assertSpyCallArgs(spotifyNow as Spy, 0, [
+      player,
+      system,
+      'spotify:track:abc123',
+      1, // default Spotify account serial number
+    ]);
+  },
+);
 
 Deno.test('command:play calls play and does NOT reset', async () => {
   const { deps, player } = makeDeps();
   const { restore } = captureLogs();
-  await process_sonos_command('command:play', deps);
+  await processSonosCommand('command:play', deps);
   restore();
   assertSpyCalls(player.play as Spy, 1);
   assertSpyCalls(player.setRepeat as Spy, 0);
@@ -80,7 +73,7 @@ Deno.test('command:play calls play and does NOT reset', async () => {
 Deno.test('command:volume/40 sets absolute volume', async () => {
   const { deps, player } = makeDeps();
   const { restore } = captureLogs();
-  await process_sonos_command('command:volume/40', deps);
+  await processSonosCommand('command:volume/40', deps);
   restore();
   assertSpyCallArgs(player.setVolume as Spy, 0, ['40']);
 });
@@ -88,52 +81,67 @@ Deno.test('command:volume/40 sets absolute volume', async () => {
 Deno.test('command:volume/+5 sets relative volume', async () => {
   const { deps, player } = makeDeps(30);
   const { restore } = captureLogs();
-  await process_sonos_command('command:volume/+5', deps);
+  await processSonosCommand('command:volume/+5', deps);
   restore();
   assertSpyCalls(player.getVolume as Spy, 1);
   assertSpyCallArgs(player.setVolume as Spy, 0, [35]);
 });
 
-Deno.test('audible floor: near-muted speaker raised to 10 on a play card', async () => {
-  const { deps, player } = makeDeps(3);
-  const { restore } = captureLogs();
-  await process_sonos_command('spotify:track:x', deps);
-  restore();
-  assertSpyCallArgs(player.setVolume as Spy, 0, [10]);
-});
+Deno.test(
+  'audible floor: near-muted speaker raised to 10 on a play card',
+  async () => {
+    const { deps, player } = makeDeps(3);
+    const { restore } = captureLogs();
+    await processSonosCommand('spotify:track:x', deps);
+    restore();
+    assertSpyCallArgs(player.setVolume as Spy, 0, [10]);
+  },
+);
 
 Deno.test('audible floor: already-audible volume left alone', async () => {
   const { deps, player } = makeDeps(20);
   const { restore } = captureLogs();
-  await process_sonos_command('favorite:Songs', deps);
+  await processSonosCommand('spotify:track:y', deps);
   restore();
   assertSpyCalls(player.setVolume as Spy, 0);
 });
 
-Deno.test('room: changes the active room and is honoured next command', async () => {
-  const { deps, system } = makeDeps();
-  const { logs, restore } = captureLogs();
-  await process_sonos_command('room:Kitchen', deps);
-  await process_sonos_command('command:play', deps);
-  restore();
-  assertEquals(logs.some((l) => l.includes('Sonos room changed to Kitchen')), true);
-  assertSpyCallArgs(system.resolveRoom as Spy, 0, ['Kitchen']);
-});
+Deno.test(
+  'room: changes the active room and is honoured next command',
+  async () => {
+    const { deps, system } = makeDeps();
+    const { logs, restore } = captureLogs();
+    await processSonosCommand('room:Kitchen', deps);
+    await processSonosCommand('command:play', deps);
+    restore();
+    assertEquals(
+      logs.some((l) => l.includes('Sonos room changed to Kitchen')),
+      true,
+    );
+    assertSpyCallArgs(system.resolveRoom as Spy, 0, ['Kitchen']);
+  },
+);
 
-Deno.test('apple: is reported unsupported with no engine call', async () => {
+Deno.test('a non-Spotify service tag is rejected with no engine call', async () => {
   const { deps, system } = makeDeps();
   const { logs, restore } = captureLogs();
-  await process_sonos_command('apple:12345', deps);
+  await processSonosCommand('apple:12345', deps);
   restore();
-  assertEquals(logs.some((l) => l.includes('not supported')), true);
+  assertEquals(
+    logs.some((l) => l.includes('not recognized')),
+    true,
+  );
   assertSpyCalls(system.resolveRoom as Spy, 0);
 });
 
-Deno.test('unrecognised prefix logs guidance', async () => {
+Deno.test('unrecognized prefix logs guidance', async () => {
   const { deps, system } = makeDeps();
   const { logs, restore } = captureLogs();
-  await process_sonos_command('wat:nope', deps);
+  await processSonosCommand('wat:nope', deps);
   restore();
-  assertEquals(logs.some((l) => l.includes('not recognised')), true);
+  assertEquals(
+    logs.some((l) => l.includes('not recognized')),
+    true,
+  );
   assertSpyCalls(system.resolveRoom as Spy, 0);
 });

--- a/lib/__tests__/settings_test.ts
+++ b/lib/__tests__/settings_test.ts
@@ -1,0 +1,37 @@
+import { assertEquals } from '@std/assert';
+import { configFilePath, DEFAULT_SETTINGS, resolveSettings } from '../settings.ts';
+
+Deno.test('configFilePath is ~/.tapdeck/config.json', () => {
+  assertEquals(configFilePath('/home/pi'), '/home/pi/.tapdeck/config.json');
+});
+
+Deno.test('configFilePath is null when HOME is unset', () => {
+  assertEquals(configFilePath(undefined), null);
+});
+
+Deno.test('resolveSettings fills every default for an empty config', () => {
+  assertEquals(resolveSettings({}), DEFAULT_SETTINGS);
+});
+
+Deno.test('resolveSettings keeps valid user values', () => {
+  const resolved = resolveSettings({
+    sonos_room: 'Kitchen',
+    reset_repeat: false,
+    min_volume: 25,
+    spotify_account_sn: 3,
+  });
+  assertEquals(resolved.sonos_room, 'Kitchen');
+  assertEquals(resolved.reset_repeat, false);
+  assertEquals(resolved.min_volume, 25);
+  assertEquals(resolved.spotify_account_sn, 3);
+  assertEquals(resolved.reset_shuffle, true); // untouched fields still default
+});
+
+Deno.test('resolveSettings coerces out-of-range / blank values to defaults', () => {
+  const resolved = resolveSettings({
+    sonos_room: '   ',
+    spotify_account_sn: 0, // must be >= 1
+  });
+  assertEquals(resolved.sonos_room, DEFAULT_SETTINGS.sonos_room);
+  assertEquals(resolved.spotify_account_sn, DEFAULT_SETTINGS.spotify_account_sn);
+});

--- a/lib/nfc/__tests__/ndef_test.ts
+++ b/lib/nfc/__tests__/ndef_test.ts
@@ -27,15 +27,21 @@ Deno.test('parses a URI record (spotify: tag)', () => {
   assertEquals(firstPayload(parseNdef(msg)), 'spotify:track:abc123');
 });
 
-Deno.test('parses a text record (favorite tag)', () => {
-  const mem = tlv(textRecord('favorite:Songs'));
-  assertEquals(firstPayload(parseNdef(extractNdefMessage(mem)!)), 'favorite:Songs');
+Deno.test('parses a text record (room tag)', () => {
+  const mem = tlv(textRecord('room:Kitchen'));
+  assertEquals(
+    firstPayload(parseNdef(extractNdefMessage(mem)!)),
+    'room:Kitchen',
+  );
 });
 
 Deno.test('skips a lock-control TLV before the NDEF TLV', () => {
   const ndef = tlv(uriRecord('command:play'));
   const mem = new Uint8Array([0x01, 0x03, 0xaa, 0xbb, 0xcc, ...ndef]); // 0x01 lock TLV, len 3
-  assertEquals(firstPayload(parseNdef(extractNdefMessage(mem)!)), 'command:play');
+  assertEquals(
+    firstPayload(parseNdef(extractNdefMessage(mem)!)),
+    'command:play',
+  );
 });
 
 Deno.test('returns null when the NDEF message is not fully read yet', () => {

--- a/lib/nfc/ndef.ts
+++ b/lib/nfc/ndef.ts
@@ -7,7 +7,7 @@ export type NdefRecord =
   | { type: 'unknown' };
 
 // NDEF URI abbreviation table (subset; index 0 = no prefix, which is what
-// `spotify:`/`favorite:` tags use).
+// `spotify:` tags use).
 const URI_PREFIXES = [
   '',
   'http://www.',
@@ -59,7 +59,9 @@ export function parseNdef(message: Uint8Array): NdefRecord[] {
     if (sr) {
       payloadLen = message[i++]!;
     } else {
-      payloadLen = (message[i]! << 24) | (message[i + 1]! << 16) | (message[i + 2]! << 8) |
+      payloadLen = (message[i]! << 24) |
+        (message[i + 1]! << 16) |
+        (message[i + 2]! << 8) |
         message[i + 3]!;
       i += 4;
     }
@@ -71,10 +73,16 @@ export function parseNdef(message: Uint8Array): NdefRecord[] {
 
     if (tnf === 0x01 && type === 'T') {
       const langLen = (payload[0] ?? 0) & 0x3f; // status byte: low 6 bits = lang code length
-      records.push({ type: 'text', text: decoder.decode(payload.slice(1 + langLen)) });
+      records.push({
+        type: 'text',
+        text: decoder.decode(payload.slice(1 + langLen)),
+      });
     } else if (tnf === 0x01 && type === 'U') {
       const prefix = URI_PREFIXES[payload[0] ?? 0] ?? '';
-      records.push({ type: 'uri', uri: prefix + decoder.decode(payload.slice(1)) });
+      records.push({
+        type: 'uri',
+        uri: prefix + decoder.decode(payload.slice(1)),
+      });
     } else {
       records.push({ type: 'unknown' });
     }

--- a/lib/nfc/pcsc.ts
+++ b/lib/nfc/pcsc.ts
@@ -6,32 +6,53 @@
 // (GetStatusChange, Transmit, Connect) are declared `nonblocking` so they run
 // off the main thread and return Promises.
 
-const LIB_PATH = Deno.env.get('PCSC_LIB') ?? 'libpcsclite.so.1';
+const SYMBOLS = {
+  SCardEstablishContext: {
+    parameters: ['u64', 'pointer', 'pointer', 'buffer'],
+    result: 'i32',
+  },
+  SCardReleaseContext: { parameters: ['u64'], result: 'i32' },
+  SCardListReaders: {
+    parameters: ['u64', 'pointer', 'buffer', 'buffer'],
+    result: 'i32',
+  },
+  SCardGetStatusChange: {
+    parameters: ['u64', 'u64', 'buffer', 'u64'],
+    result: 'i32',
+    nonblocking: true,
+  },
+  SCardConnect: {
+    parameters: ['u64', 'buffer', 'u64', 'u64', 'buffer', 'buffer'],
+    result: 'i32',
+    nonblocking: true,
+  },
+  SCardTransmit: {
+    parameters: [
+      'u64',
+      'pointer',
+      'buffer',
+      'u64',
+      'pointer',
+      'buffer',
+      'buffer',
+    ],
+    result: 'i32',
+    nonblocking: true,
+  },
+  SCardDisconnect: { parameters: ['u64', 'u64'], result: 'i32' },
+} as const;
 
-const lib = Deno.dlopen(
-  LIB_PATH,
-  {
-    SCardEstablishContext: { parameters: ['u64', 'pointer', 'pointer', 'buffer'], result: 'i32' },
-    SCardReleaseContext: { parameters: ['u64'], result: 'i32' },
-    SCardListReaders: { parameters: ['u64', 'pointer', 'buffer', 'buffer'], result: 'i32' },
-    SCardGetStatusChange: {
-      parameters: ['u64', 'u64', 'buffer', 'u64'],
-      result: 'i32',
-      nonblocking: true,
-    },
-    SCardConnect: {
-      parameters: ['u64', 'buffer', 'u64', 'u64', 'buffer', 'buffer'],
-      result: 'i32',
-      nonblocking: true,
-    },
-    SCardTransmit: {
-      parameters: ['u64', 'pointer', 'buffer', 'u64', 'pointer', 'buffer', 'buffer'],
-      result: 'i32',
-      nonblocking: true,
-    },
-    SCardDisconnect: { parameters: ['u64', 'u64'], result: 'i32' },
-  } as const,
-);
+// Open libpcsclite lazily and memoize it. Loading (and reading PCSC_LIB) at
+// import time would force every entry point (e.g. the `accounts` CLI) to depend
+// on the library and env access; only the reader actually needs them.
+let _lib: Deno.DynamicLibrary<typeof SYMBOLS> | null = null;
+function lib(): Deno.DynamicLibrary<typeof SYMBOLS> {
+  if (!_lib) {
+    const path = Deno.env.get('PCSC_LIB') ?? 'libpcsclite.so.1';
+    _lib = Deno.dlopen(path, SYMBOLS);
+  }
+  return _lib;
+}
 
 // Constants (from /usr/include/PCSC/pcsclite.h).
 export const SCARD_SCOPE_SYSTEM = 2n;
@@ -41,7 +62,7 @@ export const SCARD_LEAVE_CARD = 0n;
 export const STATE_UNAWARE = 0x0000;
 export const STATE_EMPTY = 0x0010;
 export const STATE_PRESENT = 0x0020;
-export const INFINITE = 0xFFFFFFFFn;
+export const INFINITE = 0xffffffffn;
 const S_SUCCESS = 0;
 
 // SCARD_READERSTATE layout (8-byte fields, MAX_ATR_SIZE=33):
@@ -85,24 +106,30 @@ export function cstr(s: string): Buf {
 
 export function establishContext(): bigint {
   const ctx = new Uint8Array(8);
-  check(lib.symbols.SCardEstablishContext(SCARD_SCOPE_SYSTEM, null, null, ctx), 'EstablishContext');
+  check(
+    lib().symbols.SCardEstablishContext(SCARD_SCOPE_SYSTEM, null, null, ctx),
+    'EstablishContext',
+  );
   return new DataView(ctx.buffer).getBigUint64(0, true);
 }
 
 export function releaseContext(ctx: bigint): void {
-  lib.symbols.SCardReleaseContext(ctx);
+  lib().symbols.SCardReleaseContext(ctx);
 }
 
 // Returns the reader names (the API returns a multi-string: NUL-separated, double-NUL terminated).
 export function listReaders(ctx: bigint): string[] {
   const len = new Uint8Array(8);
-  const rv1 = lib.symbols.SCardListReaders(ctx, null, null, len);
+  const rv1 = lib().symbols.SCardListReaders(ctx, null, null, len);
   if (rv1 !== S_SUCCESS) return []; // e.g. SCARD_E_NO_READERS_AVAILABLE
   const size = Number(new DataView(len.buffer).getBigUint64(0, true));
   if (!size) return [];
   const buf = new Uint8Array(size);
-  check(lib.symbols.SCardListReaders(ctx, null, buf, len), 'ListReaders');
-  return decoder.decode(buf).split('\0').filter((s) => s.length > 0);
+  check(lib().symbols.SCardListReaders(ctx, null, buf, len), 'ListReaders');
+  return decoder
+    .decode(buf)
+    .split('\0')
+    .filter((s) => s.length > 0);
 }
 
 // Build a READERSTATE buffer pointing at `readerName`, with the given current state.
@@ -124,11 +151,13 @@ export async function waitForChange(
   timeoutMs: bigint = INFINITE,
 ): Promise<number> {
   const rs = readerState(readerName, currentState);
-  const rv = await lib.symbols.SCardGetStatusChange(ctx, timeoutMs, rs, 1n);
+  const rv = await lib().symbols.SCardGetStatusChange(ctx, timeoutMs, rs, 1n);
   // 0x8010000A = SCARD_E_TIMEOUT — treat as "no change".
-  if ((rv >>> 0) === 0x8010000a) return currentState;
+  if (rv >>> 0 === 0x8010000a) return currentState;
   check(rv, 'GetStatusChange');
-  return Number(new DataView(rs.buffer).getBigUint64(RS_EVENT, true) & 0xffffffffn);
+  return Number(
+    new DataView(rs.buffer).getBigUint64(RS_EVENT, true) & 0xffffffffn,
+  );
 }
 
 export interface Card {
@@ -139,7 +168,7 @@ export interface Card {
 export async function connect(ctx: bigint, readerName: string): Promise<Card> {
   const hCard = new Uint8Array(8);
   const proto = new Uint8Array(8);
-  const rv = await lib.symbols.SCardConnect(
+  const rv = await lib().symbols.SCardConnect(
     ctx,
     cstr(readerName),
     SCARD_SHARE_SHARED,
@@ -155,7 +184,7 @@ export async function connect(ctx: bigint, readerName: string): Promise<Card> {
 }
 
 export function disconnect(card: Card): void {
-  lib.symbols.SCardDisconnect(card.handle, SCARD_LEAVE_CARD);
+  lib().symbols.SCardDisconnect(card.handle, SCARD_LEAVE_CARD);
 }
 
 // SCARD_IO_REQUEST { DWORD dwProtocol; DWORD cbPciLength; } = 16 bytes.
@@ -173,7 +202,7 @@ export async function transmit(card: Card, apdu: Buf): Promise<Uint8Array> {
   const recv = new Uint8Array(264);
   const recvLen = new Uint8Array(8);
   new DataView(recvLen.buffer).setBigUint64(0, BigInt(recv.length), true);
-  const rv = await lib.symbols.SCardTransmit(
+  const rv = await lib().symbols.SCardTransmit(
     card.handle,
     Deno.UnsafePointer.of(send),
     apdu,

--- a/lib/nfc/reader.ts
+++ b/lib/nfc/reader.ts
@@ -9,8 +9,12 @@ const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 // Connect, retrying through the transient unpowered/unresponsive states that
 // a card passes through for a moment right after it lands on the reader.
-async function connectWithRetry(ctx: bigint, readerName: string): Promise<pcsc.Card> {
-  for (let i = 0; i < 60; i++) { // ~3.6s of power-up tolerance
+async function connectWithRetry(
+  ctx: bigint,
+  readerName: string,
+): Promise<pcsc.Card> {
+  for (let i = 0; i < 60; i++) {
+    // ~3.6s of power-up tolerance
     try {
       return await pcsc.connect(ctx, readerName);
     } catch (err) {
@@ -27,13 +31,19 @@ async function connectWithRetry(ctx: bigint, readerName: string): Promise<pcsc.C
 
 // Read the NTAG user memory (from page 4) via FF B0 read APDUs until we have a
 // complete NDEF message, the tag ends, or a cap is hit. Returns the text/uri.
-async function readTag(ctx: bigint, readerName: string): Promise<string | null> {
+async function readTag(
+  ctx: bigint,
+  readerName: string,
+): Promise<string | null> {
   const card = await connectWithRetry(ctx, readerName);
   try {
     const bytes: number[] = [];
     let page = 4;
     for (let chunk = 0; chunk < 64; chunk++) {
-      const resp = await pcsc.transmit(card, new Uint8Array([0xff, 0xb0, 0x00, page & 0xff, 0x10]));
+      const resp = await pcsc.transmit(
+        card,
+        new Uint8Array([0xff, 0xb0, 0x00, page & 0xff, 0x10]),
+      );
       if (resp.length < 2) break;
       const sw1 = resp[resp.length - 2];
       const data = resp.slice(0, resp.length - 2);
@@ -50,7 +60,9 @@ async function readTag(ctx: bigint, readerName: string): Promise<string | null> 
 }
 
 // Run the reader loop forever, invoking onTag(text) for each scanned card.
-export async function startReader(onTag: (text: string) => Promise<void> | void): Promise<void> {
+export async function startReader(
+  onTag: (text: string) => Promise<void> | void,
+): Promise<void> {
   const ctx = pcsc.establishContext();
   console.log(
     'Control your Sonos with NFC cards. Searching for PCSC-compatible NFC reader devices...',

--- a/lib/pm2.ts
+++ b/lib/pm2.ts
@@ -1,0 +1,51 @@
+// Optional pm2 integration for `tapdeck setup` — registering tapdeck with the
+// pm2 process manager so it starts at boot. Isolated here so the entry point
+// stays routing + handlers, and so the only `--allow-run` use is in one place.
+
+// Run a pm2 command, capturing stdout. Returns null if pm2 isn't installed.
+async function pm2(
+  args: string[],
+): Promise<{ ok: boolean; stdout: string } | null> {
+  try {
+    const out = await new Deno.Command('pm2', {
+      args,
+      stdout: 'piped',
+      stderr: 'null',
+    }).output();
+    return { ok: out.success, stdout: new TextDecoder().decode(out.stdout) };
+  } catch {
+    return null; // not on PATH
+  }
+}
+
+// Offer to register tapdeck with pm2 so it starts at boot. Detects whether pm2
+// is installed and whether tapdeck is already managed, and only acts on a yes.
+export async function offerPm2(): Promise<void> {
+  const list = await pm2(['jlist']);
+  if (list === null) {
+    console.log(
+      '\nTo run tapdeck at boot, install pm2 (npm i -g pm2) and then:\n' +
+        '  pm2 start tapdeck --name tapdeck && pm2 save',
+    );
+    return;
+  }
+  let managed = false;
+  try {
+    managed = (JSON.parse(list.stdout || '[]') as { name?: string }[])
+      .some((p) => p?.name === 'tapdeck');
+  } catch {
+    // unparseable jlist — treat as not managed
+  }
+  if (managed) {
+    console.log('\npm2 is already managing tapdeck — autostart is set.');
+    return;
+  }
+  if (!confirm('\nStart tapdeck at boot with pm2 now?')) return;
+  // Use the running binary's own path so pm2 launches tapdeck, not a stray name.
+  await pm2(['start', Deno.execPath(), '--name', 'tapdeck']);
+  await pm2(['save']);
+  console.log(
+    'Registered with pm2. Run `pm2 startup` once and follow its instructions ' +
+      'to enable start-at-boot.',
+  );
+}

--- a/lib/process_sonos_command.ts
+++ b/lib/process_sonos_command.ts
@@ -1,46 +1,32 @@
 import { getEngine, spotify } from './sonos/index.ts';
 import type { Player } from './sonos/player.ts';
+import { loadSettings } from './settings.ts';
 
-interface Settings {
-  sonos_room?: string;
-  sonos_seed_ip?: string;
-  reset_repeat?: boolean;
-  reset_shuffle?: boolean;
-  reset_crossfade?: boolean;
-  min_volume?: number;
-}
+// loadSettings has already applied every default and coerced every value, so
+// these are final. sonos_room is reassignable via a `room:` tag, hence `let`.
+let {
+  sonos_room,
+  sonos_seed_ip,
+  reset_repeat,
+  reset_shuffle,
+  reset_crossfade,
+  min_volume,
+  spotify_account_sn,
+} = loadSettings();
 
-function loadSettings(): Settings {
-  for (const file of ['usersettings.json', 'usersettings.json.example']) {
-    try {
-      return JSON.parse(Deno.readTextFileSync(file));
-    } catch (err) {
-      if (err instanceof Deno.errors.NotFound) {
-        if (file === 'usersettings.json') {
-          console.log('usersettings.json not found, using usersettings.json.example as fallback.');
-        }
-        continue;
-      }
-      throw err;
-    }
-  }
-  return {};
-}
-
-let { sonos_room, sonos_seed_ip, reset_repeat, reset_shuffle, reset_crossfade, min_volume } =
-  loadSettings();
-
-// If a music card is scanned while the speaker is basically muted, raise it so
-// the card is actually audible. SILENT_VOLUME is the "is it muted?" trigger;
-// MIN_VOLUME (configurable) is the floor we raise to.
+// If a music card is scanned while the speaker is basically muted, raise it to
+// min_volume so the card is actually audible. SILENT_VOLUME is the "is it
+// muted?" trigger — not configurable; min_volume is the floor we raise to.
 const SILENT_VOLUME = 5;
-const MIN_VOLUME = Number.isFinite(min_volume) ? (min_volume as number) : 10;
 
 const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 // Run a best-effort pre-play reset step; log and continue if Sonos rejects it
 // (e.g. crossfade/repeat aren't valid for the current source).
-async function tryReset(label: string, fn: () => Promise<unknown>): Promise<void> {
+async function tryReset(
+  label: string,
+  fn: () => Promise<unknown>,
+): Promise<void> {
   console.log(`Resetting ${label}`);
   try {
     await fn();
@@ -48,11 +34,6 @@ async function tryReset(label: string, fn: () => Promise<unknown>): Promise<void
     console.log(`  (${label} reset skipped: ${(err as Error).message})`);
   }
 }
-
-// Music services other than Spotify are no longer supported by the in-house
-// engine. Favorites/playlists/transport still work for any service that's
-// already set up in the Sonos app.
-const UNSUPPORTED_SERVICES = ['apple', 'applemusic', 'bbcsounds', 'tunein', 'amazonmusic', 'http'];
 
 // Map a `command:` verb to a coordinator action. Args follow the verb in the
 // tag, slash-separated, e.g. `command:volume/40`, `command:repeat/all`.
@@ -118,69 +99,52 @@ export interface CommandDeps {
   spotify: Pick<typeof spotify, 'now'>;
 }
 
-export default async function process_sonos_command(
-  received_text: string,
+export default async function processSonosCommand(
+  receivedText: string,
   deps: CommandDeps = { getEngine, spotify },
 ): Promise<void> {
-  const lower = received_text.toLowerCase();
+  const lower = receivedText.toLowerCase();
 
   // Room change is purely local state — no Sonos call.
   if (lower.startsWith('room:')) {
-    sonos_room = received_text.slice(5);
+    sonos_room = receivedText.slice(5);
     console.log(`Sonos room changed to ${sonos_room}`);
     return;
   }
 
-  // Classify the tag into a { service, payload }.
-  let service: string | undefined;
-  let payload = '';
-  if (lower.startsWith('spotify:')) {
-    service = 'spotify';
-    payload = received_text; // full spotify: URI
-  } else if (lower.startsWith('favorite:')) {
-    service = 'favorite';
-    payload = received_text.slice(9);
-  } else if (lower.startsWith('playlist:')) {
-    service = 'playlist';
-    payload = received_text.slice(9);
-  } else if (lower.startsWith('command:')) {
-    service = 'command';
-    payload = received_text.slice(8);
-  } else {
-    const prefix = lower.split(':')[0] ?? '';
-    if (UNSUPPORTED_SERVICES.includes(prefix) || lower.startsWith('http')) {
-      console.log(
-        `'${prefix}' is not supported by this build (Spotify-only). ` +
-          'Use a Sonos favorite or playlist instead, or a spotify: tag.',
-      );
-      return;
-    }
+  // Only Spotify URIs, command:, and room: tags are supported.
+  const isCommand = lower.startsWith('command:');
+  if (!isCommand && !lower.startsWith('spotify:')) {
     console.log(
-      "Service type not recognised. Text should begin 'spotify', 'favorite', " +
-        "'playlist', 'command', or 'room'.",
+      'Tag not recognized. ' +
+        "Text should begin 'spotify:', 'command:', or 'room:'.",
     );
     return;
   }
 
-  console.log("Detected '%s' service request", service);
-
-  const system = await deps.getEngine(sonos_seed_ip ? { seedIp: sonos_seed_ip } : {});
-  const player = await system.resolveRoom(sonos_room ?? 'Living Room');
+  const system = await deps.getEngine(
+    sonos_seed_ip ? { seedIp: sonos_seed_ip } : {},
+  );
+  const player = await system.resolveRoom(sonos_room);
 
   // `command:` is a raw passthrough and skips the pre-play reset sequence.
-  if (service === 'command') {
-    await runCommand(player, payload);
+  if (isCommand) {
+    await runCommand(player, receivedText.slice(8));
     return;
   }
 
+  console.log('Detected Spotify request');
+
   // Reset playback state before queuing new music (best-effort cleanup of the
-  // *outgoing* source — e.g. crossfade can't be set on a radio stream / UPnP
+  // *outgoing* source — e.g. crossfade can't be set on the current source / UPnP
   // 712 — so a failure is logged and we continue to load the new track).
   if (reset_repeat) await tryReset('repeat', () => player.setRepeat('none'));
   await delay(200);
   if (reset_shuffle) await tryReset('shuffle', () => player.setShuffle(false));
   await delay(200);
-  if (reset_crossfade) await tryReset('crossfade', () => player.setCrossfade(false));
+  if (reset_crossfade) {
+    await tryReset('crossfade', () => player.setCrossfade(false));
+  }
   await delay(200);
   await tryReset('clearqueue', () => player.clearQueue());
 
@@ -188,20 +152,16 @@ export default async function process_sonos_command(
   try {
     const currentVolume = await player.getVolume();
     if (currentVolume < SILENT_VOLUME) {
-      console.log(`Volume was ${currentVolume}; raising to ${MIN_VOLUME} so the card is audible`);
-      await player.setVolume(MIN_VOLUME);
+      console.log(
+        `Volume was ${currentVolume}; raising to ${min_volume} so the card is audible`,
+      );
+      await player.setVolume(min_volume);
     }
   } catch (err) {
     console.log(`  (volume check skipped: ${(err as Error).message})`);
   }
 
-  if (service === 'spotify') {
-    await deps.spotify.now(player, system, payload);
-  } else if (service === 'favorite') {
-    await system.playFavorite(player, decodeURIComponent(payload));
-  } else if (service === 'playlist') {
-    await system.playPlaylist(player, decodeURIComponent(payload));
-  }
+  await deps.spotify.now(player, system, receivedText, spotify_account_sn);
 
   // Give Sonos a moment before the next tag is processed.
   await delay(200);

--- a/lib/settings.ts
+++ b/lib/settings.ts
@@ -1,0 +1,102 @@
+// User configuration. Loaded from a usersettings.json in the current directory
+// (dev / beside-the-binary), else ~/.tapdeck/config.json. `setup` writes the
+// latter, so the binary itself can live anywhere (e.g. /usr/local/bin) without a
+// config file beside it; run `tapdeck setup` to create one.
+
+export interface Settings {
+  sonos_room?: string;
+  sonos_seed_ip?: string;
+  reset_repeat?: boolean;
+  reset_shuffle?: boolean;
+  reset_crossfade?: boolean;
+  min_volume?: number;
+  spotify_account_sn?: number;
+}
+
+// The per-user config file: ~/.tapdeck/config.json. Pure (takes HOME) so it's
+// testable without env access; null when HOME is unset.
+export function configFilePath(home: string | undefined): string | null {
+  return home ? `${home}/.tapdeck/config.json` : null;
+}
+
+export function userConfigPath(): string | null {
+  return configFilePath(Deno.env.get('HOME') ?? undefined);
+}
+
+// Where the config may live, in priority order: a usersettings.json in the cwd,
+// then ~/.tapdeck/config.json. Single source of truth for both lookups below.
+function configCandidatePaths(): string[] {
+  const userPath = userConfigPath();
+  return ['usersettings.json', ...(userPath ? [userPath] : [])];
+}
+
+// True if the user has a real config — so a fresh install can detect first run
+// and offer `setup`.
+export function hasUserConfig(): boolean {
+  for (const file of configCandidatePaths()) {
+    try {
+      Deno.statSync(file);
+      return true;
+    } catch {
+      // not there — keep looking
+    }
+  }
+  return false;
+}
+
+function tryReadJson(path: string): Settings | undefined {
+  try {
+    return JSON.parse(Deno.readTextFileSync(path));
+  } catch (err) {
+    if (err instanceof Deno.errors.NotFound) return undefined;
+    throw err;
+  }
+}
+
+// The single source of truth for every default. Defaults live here — not in a
+// config file, and not duplicated at the call sites — so `setup` writes from
+// these and the reader resolves against them, and the value for, say,
+// min_volume exists in exactly one place.
+export const DEFAULT_SETTINGS: Required<Settings> = {
+  sonos_room: 'Living Room',
+  sonos_seed_ip: '',
+  reset_repeat: true,
+  reset_shuffle: true,
+  reset_crossfade: true,
+  min_volume: 10,
+  spotify_account_sn: 1,
+};
+
+// Fill in defaults and coerce out-of-range values, so callers get a fully
+// resolved config and never have to apply their own `?? default` /
+// `Number.isFinite` checks. Pure (takes the raw settings) so it's testable
+// without touching the disk.
+export function resolveSettings(raw: Settings): Required<Settings> {
+  return {
+    sonos_room: raw.sonos_room?.trim() || DEFAULT_SETTINGS.sonos_room,
+    sonos_seed_ip: typeof raw.sonos_seed_ip === 'string'
+      ? raw.sonos_seed_ip
+      : DEFAULT_SETTINGS.sonos_seed_ip,
+    reset_repeat: raw.reset_repeat ?? DEFAULT_SETTINGS.reset_repeat,
+    reset_shuffle: raw.reset_shuffle ?? DEFAULT_SETTINGS.reset_shuffle,
+    reset_crossfade: raw.reset_crossfade ?? DEFAULT_SETTINGS.reset_crossfade,
+    min_volume: Number.isFinite(raw.min_volume) ? raw.min_volume! : DEFAULT_SETTINGS.min_volume,
+    spotify_account_sn: Number.isInteger(raw.spotify_account_sn) && raw.spotify_account_sn! >= 1
+      ? raw.spotify_account_sn!
+      : DEFAULT_SETTINGS.spotify_account_sn,
+  };
+}
+
+function loadRawSettings(): Settings {
+  for (const file of configCandidatePaths()) {
+    const found = tryReadJson(file);
+    if (found) return found;
+  }
+  return {};
+}
+
+// The user config with all defaults applied and values coerced — the only shape
+// the rest of the app sees.
+export function loadSettings(): Required<Settings> {
+  return resolveSettings(loadRawSettings());
+}

--- a/lib/sonos/__tests__/soap_test.ts
+++ b/lib/sonos/__tests__/soap_test.ts
@@ -11,7 +11,11 @@ Deno.test('buildEnvelope wraps the SOAP body', () => {
 
 Deno.test('buildBody namespaces the action and embeds args', () => {
   assertEquals(
-    buildBody(URN.AVTransport, 'Play', '<InstanceID>0</InstanceID><Speed>1</Speed>'),
+    buildBody(
+      URN.AVTransport,
+      'Play',
+      '<InstanceID>0</InstanceID><Speed>1</Speed>',
+    ),
     '<u:Play xmlns:u="urn:schemas-upnp-org:service:AVTransport:1">' +
       '<InstanceID>0</InstanceID><Speed>1</Speed></u:Play>',
   );
@@ -20,5 +24,8 @@ Deno.test('buildBody namespaces the action and embeds args', () => {
 Deno.test('control paths and URNs are the Sonos-expected values', () => {
   assertEquals(PATH.AVTransport, '/MediaRenderer/AVTransport/Control');
   assertEquals(PATH.ContentDirectory, '/MediaServer/ContentDirectory/Control');
-  assertEquals(URN.ContentDirectory, 'urn:schemas-upnp-org:service:ContentDirectory:1');
+  assertEquals(
+    URN.ContentDirectory,
+    'urn:schemas-upnp-org:service:ContentDirectory:1',
+  );
 });

--- a/lib/sonos/__tests__/spotify_test.ts
+++ b/lib/sonos/__tests__/spotify_test.ts
@@ -4,16 +4,40 @@ import { buildSpotifyTrack } from '../services/spotify.ts';
 const service = { id: 12, type: 3079 }; // verified against the live Office system
 
 Deno.test('track URI uses x-sonos-spotify with sid/flags/sn', () => {
-  const { uri, metadata } = buildSpotifyTrack('spotify:track:4uLU6hMCjMI75M1A2tKUQC', service);
+  const { uri, metadata } = buildSpotifyTrack(
+    'spotify:track:4uLU6hMCjMI75M1A2tKUQC',
+    service,
+  );
   assertEquals(
     uri,
     'x-sonos-spotify:spotify%3Atrack%3A4uLU6hMCjMI75M1A2tKUQC?sid=12&flags=32&sn=1',
   );
   assertStringIncludes(metadata, 'SA_RINCON3079_X_#Svc3079-0-Token');
-  assertStringIncludes(metadata, 'id="00030020spotify%3Atrack%3A4uLU6hMCjMI75M1A2tKUQC"');
+  assertStringIncludes(
+    metadata,
+    'id="00030020spotify%3Atrack%3A4uLU6hMCjMI75M1A2tKUQC"',
+  );
+});
+
+Deno.test('a non-default account changes only sn; cdudn token stays -0-', () => {
+  const { uri, metadata } = buildSpotifyTrack(
+    'spotify:track:4uLU6hMCjMI75M1A2tKUQC',
+    service,
+    2,
+  );
+  assertStringIncludes(uri, '&sn=2');
+  // Verified against the live Office system: a real sn=2 Spotify favorite still
+  // carries the -0- token, so the account lives in `sn`, not the cdudn token.
+  assertStringIncludes(metadata, 'SA_RINCON3079_X_#Svc3079-0-Token');
 });
 
 Deno.test('album/playlist URI uses x-rincon-cpcontainer', () => {
-  const { uri } = buildSpotifyTrack('spotify:album:1DFixLWuPkv3KT3TnV35m3', service);
-  assertEquals(uri, 'x-rincon-cpcontainer:0006206cspotify%3Aalbum%3A1DFixLWuPkv3KT3TnV35m3');
+  const { uri } = buildSpotifyTrack(
+    'spotify:album:1DFixLWuPkv3KT3TnV35m3',
+    service,
+  );
+  assertEquals(
+    uri,
+    'x-rincon-cpcontainer:0006206cspotify%3Aalbum%3A1DFixLWuPkv3KT3TnV35m3',
+  );
 });

--- a/lib/sonos/__tests__/system_test.ts
+++ b/lib/sonos/__tests__/system_test.ts
@@ -21,24 +21,53 @@ const SERVICES = `<AvailableServiceDescriptorList>${
   )
 }</AvailableServiceDescriptorList>`;
 
+// Cdudn metadata for a Spotify favorite under account `token` (3079 = Spotify).
+const spotifyResMD = (token: string) =>
+  encodeEntities(
+    `<DIDL-Lite><desc id="cdudn">SA_RINCON3079_X_#Svc3079-${token}-Token</desc></DIDL-Lite>`,
+  );
+
 const FAV_DIDL = '<DIDL-Lite>' +
   '<item id="FV:2/1"><dc:title>Radio One</dc:title>' +
   '<res protocolInfo="x-sonosapi-hls:*:*:*">x-sonosapi-hls:foo?sid=37&amp;flags=296</res>' +
   `<r:resMD>${encodeEntities('<DIDL-Lite>radio-meta</DIDL-Lite>')}</r:resMD></item>` +
+  // Spotify account "0" — has a playable favorite, so its sn=2 is discoverable.
   '<item id="FV:2/2"><dc:title>Songs</dc:title>' +
-  '<res protocolInfo="x-rincon-cpcontainer:*">x-rincon-cpcontainer:100e206cyour_songs?sid=12&amp;flags=8</res></item>' +
+  '<res protocolInfo="x-rincon-cpcontainer:*">x-rincon-cpcontainer:100e206cyour_songs?sid=12&amp;flags=8&amp;sn=2</res>' +
+  `<r:resMD>${spotifyResMD('0')}</r:resMD></item>` +
+  // A second Spotify account "61a1d0cb" — only a shortcut favorite (empty res),
+  // so its sn can't be discovered.
+  '<item id="FV:2/3"><dc:title>Discover Weekly</dc:title><res></res>' +
+  `<r:resMD>${spotifyResMD('61a1d0cb')}</r:resMD></item>` +
   '</DIDL-Lite>';
-const FAVORITES = `<Result>${encodeEntities(FAV_DIDL)}</Result><NumberReturned>2</NumberReturned>`;
+const FAVORITES = `<Result>${encodeEntities(FAV_DIDL)}</Result><NumberReturned>3</NumberReturned>`;
+
+// A room queue holding a Spotify track from the second account (61a1d0cb) — its
+// res URI carries sn=3, which no favorite under that account revealed.
+const QUEUE_DIDL = '<DIDL-Lite>' +
+  '<item id="Q:0/1"><dc:title>Some Track</dc:title>' +
+  '<res protocolInfo="x-sonos-spotify:*">x-sonos-spotify:spotify%3atrack%3aX?sid=12&amp;flags=32&amp;sn=3</res>' +
+  `<r:resMD>${spotifyResMD('61a1d0cb')}</r:resMD></item>` +
+  // A queued track with sn=2 but no cdudn token — must merge into account "0".
+  '<item id="Q:0/2"><dc:title>Queued Hit</dc:title>' +
+  '<res protocolInfo="x-sonos-spotify:*">x-sonos-spotify:spotify%3atrack%3aY?sid=12&amp;flags=32&amp;sn=2</res></item>' +
+  '</DIDL-Lite>';
+const QUEUE = `<Result>${encodeEntities(QUEUE_DIDL)}</Result><NumberReturned>1</NumberReturned>`;
 
 // Stub the network; the real soap.ts/xml.ts pipeline runs end-to-end.
 function withStubbedFetch(): () => void {
   const original = globalThis.fetch;
-  globalThis.fetch = (_url: string | URL | Request, opts?: RequestInit): Promise<Response> => {
+  globalThis.fetch = (
+    _url: string | URL | Request,
+    opts?: RequestInit,
+  ): Promise<Response> => {
     const body = String(opts?.body ?? '');
     let xml = '';
     if (body.includes('GetZoneGroupState')) xml = TOPOLOGY;
     else if (body.includes('ListAvailableServices')) xml = SERVICES;
-    else if (body.includes('Browse')) xml = body.includes('FV:2') ? FAVORITES : '<Result></Result>';
+    else if (body.includes('Browse')) {
+      xml = body.includes('FV:2') ? FAVORITES : body.includes('Q:0') ? QUEUE : '<Result></Result>';
+    }
     return Promise.resolve(new Response(xml, { status: 200 }));
   };
   return () => {
@@ -50,28 +79,55 @@ async function booted(): Promise<SonosSystem> {
   return await new SonosSystem({ seedIp: '192.168.0.195' }).bootstrap();
 }
 
-Deno.test('resolveRoom("Office") returns the coordinator (.195), not the invisible .113', async () => {
+Deno.test('listRooms returns each room (original casing) with its coordinator IP', async () => {
   const restore = withStubbedFetch();
   try {
-    const p = await (await booted()).resolveRoom('office');
-    assertEquals(p.uuid, 'RINCON_OFFICE195');
-    assertEquals(p.baseUrl, 'http://192.168.0.195:1400');
+    assertEquals((await booted()).listRooms(), [
+      { name: 'Kitchen', ip: '192.168.0.96' },
+      { name: 'Office', ip: '192.168.0.195' },
+    ]);
   } finally {
     restore();
   }
 });
 
-Deno.test('resolveRoom is case-insensitive and resolves other rooms', async () => {
+Deno.test('connectedIp reports the player tapdeck is talking to', async () => {
   const restore = withStubbedFetch();
   try {
-    assertEquals(
-      (await (await booted()).resolveRoom('Kitchen')).baseUrl,
-      'http://192.168.0.96:1400',
-    );
+    assertEquals((await booted()).connectedIp, '192.168.0.195');
   } finally {
     restore();
   }
 });
+
+Deno.test(
+  'resolveRoom("Office") returns the coordinator (.195), not the invisible .113',
+  async () => {
+    const restore = withStubbedFetch();
+    try {
+      const p = await (await booted()).resolveRoom('office');
+      assertEquals(p.uuid, 'RINCON_OFFICE195');
+      assertEquals(p.baseUrl, 'http://192.168.0.195:1400');
+    } finally {
+      restore();
+    }
+  },
+);
+
+Deno.test(
+  'resolveRoom is case-insensitive and resolves other rooms',
+  async () => {
+    const restore = withStubbedFetch();
+    try {
+      assertEquals(
+        (await (await booted()).resolveRoom('Kitchen')).baseUrl,
+        'http://192.168.0.96:1400',
+      );
+    } finally {
+      restore();
+    }
+  },
+);
 
 Deno.test('unknown room throws', async () => {
   const restore = withStubbedFetch();
@@ -86,21 +142,49 @@ Deno.test('unknown room throws', async () => {
 Deno.test('getSpotifyService derives id 12 -> serviceType 3079', async () => {
   const restore = withStubbedFetch();
   try {
-    assertEquals(await (await booted()).getSpotifyService(), { id: 12, type: 3079 });
+    assertEquals(await (await booted()).getSpotifyService(), {
+      id: 12,
+      type: 3079,
+    });
   } finally {
     restore();
   }
 });
 
-Deno.test('getFavorites parses titles and double-decoded uri/metadata', async () => {
-  const restore = withStubbedFetch();
-  try {
-    const favs = await (await booted()).getFavorites();
-    assertEquals(favs.map((f) => f.title), ['Radio One', 'Songs']);
-    const radio = favs[0]!;
-    assertEquals(radio.uri, 'x-sonosapi-hls:foo?sid=37&flags=296');
-    assertEquals(radio.metadata, '<DIDL-Lite>radio-meta</DIDL-Lite>');
-  } finally {
-    restore();
-  }
-});
+Deno.test(
+  'getFavorites parses titles and double-decoded uri/metadata',
+  async () => {
+    const restore = withStubbedFetch();
+    try {
+      const favs = await (await booted()).getFavorites();
+      assertEquals(
+        favs.map((f) => f.title),
+        ['Radio One', 'Songs', 'Discover Weekly'],
+      );
+      const radio = favs[0]!;
+      assertEquals(radio.uri, 'x-sonosapi-hls:foo?sid=37&flags=296');
+      assertEquals(radio.metadata, '<DIDL-Lite>radio-meta</DIDL-Lite>');
+    } finally {
+      restore();
+    }
+  },
+);
+
+Deno.test(
+  'getSpotifyAccounts groups by account token, filling sn from favorites and queues',
+  async () => {
+    const restore = withStubbedFetch();
+    try {
+      // Account "0" gets sn=2 from the "Songs" favorite, and the token-less
+      // "Queued Hit" (sn=2) merges into it. Account "61a1d0cb" has no playable
+      // favorite, but its queued "Some Track" supplies sn=3 and pulls in the
+      // token-only "Discover Weekly" favorite. TuneIn (sid=37) is ignored.
+      assertEquals(await (await booted()).getSpotifyAccounts(), [
+        { token: '0', sn: 2, examples: ['Songs', 'Queued Hit'] },
+        { token: '61a1d0cb', sn: 3, examples: ['Discover Weekly', 'Some Track'] },
+      ]);
+    } finally {
+      restore();
+    }
+  },
+);

--- a/lib/sonos/__tests__/xml_test.ts
+++ b/lib/sonos/__tests__/xml_test.ts
@@ -1,8 +1,9 @@
 import { assertEquals } from '@std/assert';
 import { decodeEntities, encodeEntities, getAttr, getTagBlocks, getTagText } from '../xml.ts';
 
-Deno.test('encodeEntities escapes & first', () => {
-  assertEquals(encodeEntities('a&b<c>"d\''), 'a&amp;b&lt;c&gt;&quot;d&apos;');
+Deno.test('encodeEntities escapes all five predefined entities', () => {
+  // `'` is emitted as the numeric &#39; (std default), which is valid XML.
+  assertEquals(encodeEntities('a&b<c>"d\''), 'a&amp;b&lt;c&gt;&quot;d&#39;');
 });
 
 Deno.test('encode/decode round-trips', () => {
@@ -14,6 +15,17 @@ Deno.test('decodeEntities handles numeric apostrophe', () => {
   assertEquals(decodeEntities('it&#39;s &amp; that'), "it's & that");
 });
 
+Deno.test('decodeEntities handles both apostrophe forms', () => {
+  // &apos; is XML-only; &#39; is what we emit — both must decode.
+  assertEquals(decodeEntities('it&apos;s vs it&#39;s'), "it's vs it's");
+});
+
+Deno.test('decodeEntities decodes decimal & hex numeric entities (regression)', () => {
+  // The old hand-rolled decoder only knew &#39;/&#34; and passed these through.
+  assertEquals(decodeEntities('Caf&#233; &#8212; Beatles'), 'Café — Beatles');
+  assertEquals(decodeEntities('Caf&#xe9; &#x2014; Beatles'), 'Café — Beatles');
+});
+
 Deno.test('double-decode recovers nested DIDL (resMD style)', () => {
   const inner = '<DIDL-Lite>&meta</DIDL-Lite>';
   const onceEncoded = encodeEntities(inner);
@@ -22,7 +34,10 @@ Deno.test('double-decode recovers nested DIDL (resMD style)', () => {
 });
 
 Deno.test('getTagText pulls namespaced tag content', () => {
-  assertEquals(getTagText('<a><dc:title>Hello</dc:title></a>', 'dc:title'), 'Hello');
+  assertEquals(
+    getTagText('<a><dc:title>Hello</dc:title></a>', 'dc:title'),
+    'Hello',
+  );
   assertEquals(getTagText('<a/>', 'missing'), undefined);
 });
 
@@ -32,6 +47,9 @@ Deno.test('getTagBlocks returns each block incl. self-closing', () => {
 });
 
 Deno.test('getAttr reads an attribute', () => {
-  assertEquals(getAttr('<m UUID="abc" ZoneName="Office"/>', 'ZoneName'), 'Office');
+  assertEquals(
+    getAttr('<m UUID="abc" ZoneName="Office"/>', 'ZoneName'),
+    'Office',
+  );
   assertEquals(getAttr('<m/>', 'UUID'), undefined);
 });

--- a/lib/sonos/discovery.ts
+++ b/lib/sonos/discovery.ts
@@ -22,9 +22,9 @@ const M_SEARCH = Buffer.from(
 );
 
 // Resolve to { ip } of the first ZonePlayer that answers, or reject on timeout.
-export function discoverAnyPlayer({ timeout = 5000 }: { timeout?: number } = {}): Promise<
-  { ip: string }
-> {
+export function discoverAnyPlayer({
+  timeout = 5000,
+}: { timeout?: number } = {}): Promise<{ ip: string }> {
   return new Promise((resolve, reject) => {
     const socket = dgram.createSocket({ type: 'udp4', reuseAddr: true });
     let done = false;
@@ -61,14 +61,19 @@ export function discoverAnyPlayer({ timeout = 5000 }: { timeout?: number } = {})
         // some platforms restrict these; multicast send still works
       }
       const send = () => {
-        if (!done) socket.send(M_SEARCH, 0, M_SEARCH.length, SSDP_PORT, SSDP_ADDR);
+        if (!done) {
+          socket.send(M_SEARCH, 0, M_SEARCH.length, SSDP_PORT, SSDP_ADDR);
+        }
       };
       send();
       retryTimer = setInterval(send, 1000);
     });
 
     const deadline = setTimeout(
-      () => finish(new Error(`No Sonos ZonePlayer found within ${timeout}ms (SSDP)`)),
+      () =>
+        finish(
+          new Error(`No Sonos ZonePlayer found within ${timeout}ms (SSDP)`),
+        ),
       timeout,
     );
   });

--- a/lib/sonos/index.ts
+++ b/lib/sonos/index.ts
@@ -9,7 +9,9 @@ let enginePromise: Promise<SonosSystem> | null = null;
 
 // Returns the cached SonosSystem, bootstrapping (discover + topology) on first call.
 // `opts.seedIp` skips SSDP discovery and talks to a known player directly.
-export function getEngine(opts: { seedIp?: string } = {}): Promise<SonosSystem> {
+export function getEngine(
+  opts: { seedIp?: string } = {},
+): Promise<SonosSystem> {
   if (!enginePromise) {
     enginePromise = new SonosSystem(opts).bootstrap().catch((err) => {
       enginePromise = null; // allow retry on next tap

--- a/lib/sonos/player.ts
+++ b/lib/sonos/player.ts
@@ -17,7 +17,13 @@ const PLAYMODE: Record<string, { shuffle: boolean; repeat: Repeat }> = {
   SHUFFLE_REPEAT_ONE: { shuffle: true, repeat: 'one' },
 };
 
-function encodePlayMode({ shuffle, repeat }: { shuffle: boolean; repeat: Repeat }): string {
+function encodePlayMode({
+  shuffle,
+  repeat,
+}: {
+  shuffle: boolean;
+  repeat: Repeat;
+}): string {
   for (const [name, v] of Object.entries(PLAYMODE)) {
     if (v.shuffle === shuffle && v.repeat === repeat) return name;
   }
@@ -38,10 +44,23 @@ export class Player {
     args = '<InstanceID>0</InstanceID>',
     opts?: { timeout?: number },
   ): Promise<string> {
-    return invoke(this.baseUrl, PATH.AVTransport, URN.AVTransport, action, args, opts);
+    return invoke(
+      this.baseUrl,
+      PATH.AVTransport,
+      URN.AVTransport,
+      action,
+      args,
+      opts,
+    );
   }
   private _rc(action: string, args: string): Promise<string> {
-    return invoke(this.baseUrl, PATH.RenderingControl, URN.RenderingControl, action, args);
+    return invoke(
+      this.baseUrl,
+      PATH.RenderingControl,
+      URN.RenderingControl,
+      action,
+      args,
+    );
   }
 
   play(): Promise<string> {
@@ -89,26 +108,40 @@ export class Player {
     return this.mute(false);
   }
   async getVolume(): Promise<number> {
-    const res = await this._rc('GetVolume', '<InstanceID>0</InstanceID><Channel>Master</Channel>');
+    const res = await this._rc(
+      'GetVolume',
+      '<InstanceID>0</InstanceID><Channel>Master</Channel>',
+    );
     return parseInt(getTagText(res, 'CurrentVolume') || '0', 10);
   }
 
-  async getPlayMode(): Promise<string> {
+  // PlayMode is packed (repeat+shuffle); these stay private because callers only
+  // ever want to flip one dimension, which setRepeat/setShuffle below expose.
+  private async _getPlayMode(): Promise<string> {
     const res = await this._av('GetTransportSettings');
     return getTagText(res, 'PlayMode') || 'NORMAL';
   }
-  setPlayMode(mode: string): Promise<string> {
-    return this._av('SetPlayMode', `<InstanceID>0</InstanceID><NewPlayMode>${mode}</NewPlayMode>`);
+  private _setPlayMode(mode: string): Promise<string> {
+    return this._av(
+      'SetPlayMode',
+      `<InstanceID>0</InstanceID><NewPlayMode>${mode}</NewPlayMode>`,
+    );
   }
   // Flip only the repeat dimension, preserving shuffle.
   async setRepeat(repeat: Repeat): Promise<string> {
-    const cur = PLAYMODE[await this.getPlayMode()] ?? { shuffle: false, repeat: 'none' as Repeat };
-    return this.setPlayMode(encodePlayMode({ shuffle: cur.shuffle, repeat }));
+    const cur = PLAYMODE[await this._getPlayMode()] ?? {
+      shuffle: false,
+      repeat: 'none' as Repeat,
+    };
+    return this._setPlayMode(encodePlayMode({ shuffle: cur.shuffle, repeat }));
   }
   // Flip only the shuffle dimension, preserving repeat.
   async setShuffle(shuffle: boolean): Promise<string> {
-    const cur = PLAYMODE[await this.getPlayMode()] ?? { shuffle: false, repeat: 'none' as Repeat };
-    return this.setPlayMode(encodePlayMode({ shuffle, repeat: cur.repeat }));
+    const cur = PLAYMODE[await this._getPlayMode()] ?? {
+      shuffle: false,
+      repeat: 'none' as Repeat,
+    };
+    return this._setPlayMode(encodePlayMode({ shuffle, repeat: cur.repeat }));
   }
 
   async getTransportState(): Promise<string> {
@@ -147,6 +180,12 @@ export class Player {
       { timeout: 12000 },
     );
     return parseInt(getTagText(res, 'FirstTrackNumberEnqueued') || '1', 10);
+  }
+
+  // The transport URI for this coordinator's own queue (track 0). Owning the
+  // `x-rincon-queue:` scheme here keeps queue-addressing detail out of callers.
+  queueUri(): string {
+    return `x-rincon-queue:${this.uuid}#0`;
   }
 
   // Raw ContentDirectory Browse; caller parses the <Result> DIDL.

--- a/lib/sonos/services/spotify.ts
+++ b/lib/sonos/services/spotify.ts
@@ -18,13 +18,18 @@ function buildMetadata(encodedUri: string, serviceType: number): string {
 }
 
 // Build the { uri, metadata } a Sonos coordinator needs for a Spotify item.
+// `accountSn` is the Sonos account serial number — which linked Spotify account
+// to play from (1 = the first/default account). It selects the account via the
+// track URI's `sn=`; the cdudn metadata token stays at `-0-` (observed constant
+// across accounts on real systems — `sn` is the actual account selector).
 export function buildSpotifyTrack(
   spotifyUri: string,
   service: SpotifyService,
+  accountSn = 1,
 ): { uri: string; metadata: string } {
   const enc = encodeURIComponent(spotifyUri);
   const uri = spotifyUri.startsWith('spotify:track:')
-    ? `x-sonos-spotify:${enc}?sid=${service.id}&flags=32&sn=1`
+    ? `x-sonos-spotify:${enc}?sid=${service.id}&flags=32&sn=${accountSn}`
     : `x-rincon-cpcontainer:0006206c${enc}`;
   return { uri, metadata: buildMetadata(enc, service.type) };
 }
@@ -34,10 +39,11 @@ export async function now(
   coordinator: Player,
   system: SonosSystem,
   spotifyUri: string,
+  accountSn = 1,
 ): Promise<string> {
   const service = await system.getSpotifyService();
-  const { uri, metadata } = buildSpotifyTrack(spotifyUri, service);
-  await coordinator.setAVTransport(`x-rincon-queue:${coordinator.uuid}#0`);
+  const { uri, metadata } = buildSpotifyTrack(spotifyUri, service, accountSn);
+  await coordinator.setAVTransport(coordinator.queueUri());
   const firstTrack = await coordinator.addURIToQueue(uri, metadata, true, 1);
   await coordinator.trackSeek(firstTrack);
   return coordinator.play();

--- a/lib/sonos/soap.ts
+++ b/lib/sonos/soap.ts
@@ -57,12 +57,17 @@ export async function invoke(
     });
     const text = await res.text();
     if (!res.ok) {
-      throw new Error(`SOAP ${action} -> HTTP ${res.status}: ${text.slice(0, 300)}`);
+      throw new Error(
+        `SOAP ${action} -> HTTP ${res.status}: ${text.slice(0, 300)}`,
+      );
     }
     return text;
   } catch (err) {
     if (err instanceof Error && err.name === 'AbortError') {
-      throw new Error(`SOAP ${action} timed out after ${timeout}ms (${baseUrl}${path})`);
+      throw new Error(
+        `SOAP ${action} timed out after ${timeout}ms (${baseUrl}${path})`,
+        { cause: err },
+      );
     }
     throw err;
   } finally {

--- a/lib/sonos/system.ts
+++ b/lib/sonos/system.ts
@@ -1,5 +1,5 @@
-// Owns discovery bootstrap, topology (room -> group coordinator), music-service
-// lookup, and favorites/playlists. One instance is cached for the process.
+// Owns discovery bootstrap, topology (room -> group coordinator), the Spotify
+// service lookup, and Spotify-account discovery. One instance cached per process.
 
 import { discoverAnyPlayer } from './discovery.ts';
 import { Player } from './player.ts';
@@ -15,21 +15,26 @@ export interface MediaItem {
   uri: string;
   metadata: string;
 }
+// A linked Spotify account discovered from favorites/queues. `sn` is the value
+// for `spotify_account_sn` (null if no playable item revealed it); `token` is
+// the Sonos account token; `examples` are tracks under it, for recognition.
+export interface SpotifyAccount {
+  token: string | null;
+  sn: number | null;
+  examples: string[];
+}
 
-const RADIO_PREFIXES = [
-  'x-sonosapi-stream:',
-  'x-sonosapi-radio:',
-  'x-sonosapi-hls:',
-  'x-sonosapi-hls-static:',
-  'x-sonosprog-http:',
-  'x-rincon-mp3radio:',
-  'pndrradio:',
-  'hls-radio:',
-];
+// A room and the group coordinator that controls it. `name` keeps the original
+// casing for display; the map is keyed by the lowercased name for lookup.
+interface Zone {
+  coordinatorUuid: string;
+  baseUrl: string;
+  name: string;
+}
 
 export class SonosSystem {
   private _seedBaseUrl: string | null;
-  private _rooms = new Map<string, { coordinatorUuid: string; baseUrl: string }>();
+  private _rooms = new Map<string, Zone>();
   private _spotify: SpotifyService | null = null;
 
   constructor({ seedIp }: { seedIp?: string } = {}) {
@@ -41,11 +46,22 @@ export class SonosSystem {
       const { ip } = await discoverAnyPlayer();
       this._seedBaseUrl = `http://${ip}:1400`;
     }
-    await this.refreshTopology();
-    return this;
+    // A player in network sleep can miss the first request; retry a few times
+    // (each attempt also helps wake it) before giving up.
+    let lastErr: unknown;
+    for (let attempt = 0; attempt < 4; attempt++) {
+      try {
+        await this.refreshTopology();
+        return this;
+      } catch (err) {
+        lastErr = err;
+        await new Promise((r) => setTimeout(r, 300));
+      }
+    }
+    throw lastErr;
   }
 
-  async refreshTopology(): Promise<Map<string, { coordinatorUuid: string; baseUrl: string }>> {
+  async refreshTopology(): Promise<Map<string, Zone>> {
     const res = await invoke(
       this._seedBaseUrl!,
       PATH.ZoneGroupTopology,
@@ -53,19 +69,27 @@ export class SonosSystem {
       'GetZoneGroupState',
     );
     const state = decodeEntities(getTagText(res, 'ZoneGroupState') || '');
-    const rooms = new Map<string, { coordinatorUuid: string; baseUrl: string }>();
+    const rooms = new Map<string, Zone>();
     for (const group of getTagBlocks(state, 'ZoneGroup')) {
       const openTag = group.match(/^<ZoneGroup\b[^>]*>/)?.[0] || '';
       const coordinatorUuid = getAttr(openTag, 'Coordinator');
       const members = group.match(/<ZoneGroupMember\b[^>]*>/g) || [];
-      const coordTag = members.find((m) => getAttr(m, 'UUID') === coordinatorUuid);
+      const coordTag = members.find(
+        (m) => getAttr(m, 'UUID') === coordinatorUuid,
+      );
       if (!coordTag || !coordinatorUuid) continue;
       const coordBaseUrl = locationToBaseUrl(getAttr(coordTag, 'Location'));
       if (!coordBaseUrl) continue;
       for (const m of members) {
         if (getAttr(m, 'Invisible') === '1') continue; // sub/right-channel/bridge
         const name = getAttr(m, 'ZoneName');
-        if (name) rooms.set(name.toLowerCase(), { coordinatorUuid, baseUrl: coordBaseUrl });
+        if (name) {
+          rooms.set(name.toLowerCase(), {
+            coordinatorUuid,
+            baseUrl: coordBaseUrl,
+            name,
+          });
+        }
       }
     }
     if (rooms.size) this._rooms = rooms;
@@ -88,6 +112,20 @@ export class SonosSystem {
     return new Player({ uuid: entry.coordinatorUuid, baseUrl: entry.baseUrl });
   }
 
+  // Every room name (original casing) with the IP of its group coordinator,
+  // sorted by name — for the `status` setup helper.
+  listRooms(): { name: string; ip: string }[] {
+    return [...this._rooms.values()]
+      .map((z) => ({ name: z.name, ip: hostOf(z.baseUrl) }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  // The IP tapdeck is talking to (discovered or seeded) — a candidate for
+  // `sonos_seed_ip`. Null until bootstrap has run.
+  get connectedIp(): string | null {
+    return this._seedBaseUrl ? hostOf(this._seedBaseUrl) : null;
+  }
+
   // { id, type } for Spotify (type = (id<<8)+7), derived at runtime and cached.
   async getSpotifyService(): Promise<SpotifyService> {
     if (this._spotify) return this._spotify;
@@ -97,7 +135,9 @@ export class SonosSystem {
       URN.MusicServices,
       'ListAvailableServices',
     );
-    const list = decodeEntities(getTagText(res, 'AvailableServiceDescriptorList') || '');
+    const list = decodeEntities(
+      getTagText(res, 'AvailableServiceDescriptorList') || '',
+    );
     for (const svc of list.match(/<Service\b[^>]*>/g) || []) {
       if (getAttr(svc, 'Name') === 'Spotify') {
         const id = parseInt(getAttr(svc, 'Id') || '', 10);
@@ -105,22 +145,105 @@ export class SonosSystem {
         return this._spotify;
       }
     }
-    throw new Error('Spotify is not configured in your Sonos app (no Spotify service found)');
+    throw new Error(
+      'Spotify is not configured in your Sonos app (no Spotify service found)',
+    );
   }
 
+  // Browse the household's "My Sonos" favorites. Kept (even though tapdeck plays
+  // Spotify only) because `getSpotifyAccounts` mines favorite metadata for the
+  // Spotify account serial numbers.
   getFavorites(): Promise<MediaItem[]> {
     return this._browseItems('FV:2');
   }
-  getPlaylists(): Promise<MediaItem[]> {
-    return this._browseItems('SQ:');
+
+  // The linked Spotify accounts discovered from the user's favorites, so they
+  // can pick one for `spotify_account_sn`. Each account is keyed by its Sonos
+  // account token (the `-<token>-` in the favorite's cdudn metadata — the only
+  // stable per-account identifier available locally, since S2 doesn't expose
+  // usernames over the LAN), with the `sn` serial number to put in the setting
+  // (null if no favorite under it has a playable `sn=` URI) and the favorites
+  // that belong to it for recognition. Sorted with known-`sn` accounts first.
+  async getSpotifyAccounts(): Promise<SpotifyAccount[]> {
+    const { id, type } = await this.getSpotifyService();
+    const tokenRe = new RegExp(`SA_RINCON${type}_X_#Svc${type}-([^-]+)-Token`);
+    const sidRe = new RegExp(`[?&]sid=${id}(?:&|$)`);
+
+    // Favorites are household-wide; queues are per-coordinator, so also scan
+    // each group's queue. A queued Spotify track carries `sn=` directly, which
+    // can reveal an account (and its serial number) that no favorite does.
+    const items: MediaItem[] = [...await this.getFavorites()];
+    const seen = new Set<string>();
+    for (const { coordinatorUuid, baseUrl } of this._rooms.values()) {
+      if (seen.has(baseUrl)) continue; // one queue per coordinator
+      seen.add(baseUrl);
+      try {
+        items.push(
+          ...await this._browseItems(
+            'Q:0',
+            new Player({ uuid: coordinatorUuid, baseUrl }),
+          ),
+        );
+      } catch {
+        // a group with an empty or unreachable queue — skip it
+      }
+    }
+
+    // Each item may carry a token (from metadata), an sn (from the URI), or
+    // both — favorites tend to have the token, queue tracks the sn. Collect the
+    // raw signals first.
+    const raw: { token: string | null; sn: number | null; title: string }[] = [];
+    for (const item of items) {
+      const tokenMatch = item.metadata.match(tokenRe);
+      const isSpotify = sidRe.test(item.uri);
+      if (!tokenMatch && !isSpotify) continue;
+      const snMatch = isSpotify ? item.uri.match(/[?&]sn=(\d+)/) : null;
+      raw.push({
+        token: tokenMatch ? tokenMatch[1]! : null,
+        sn: snMatch ? parseInt(snMatch[1]!, 10) : null,
+        title: item.title,
+      });
+    }
+
+    // An account is uniquely identified by its sn, so learn token→sn from items
+    // that expose both, then group by sn (falling back to token when no sn is
+    // known anywhere). This merges, say, a token-less queued track into the
+    // account a favorite established under the same sn.
+    const tokenToSn = new Map<string, number>();
+    for (const r of raw) if (r.token && r.sn !== null) tokenToSn.set(r.token, r.sn);
+
+    const accounts = new Map<
+      string,
+      { token: string | null; sn: number | null; examples: Set<string> }
+    >();
+    for (const r of raw) {
+      const sn = r.sn ?? (r.token ? tokenToSn.get(r.token) ?? null : null);
+      const key = sn !== null ? `sn:${sn}` : `token:${r.token}`;
+      const acc = accounts.get(key) ??
+        { token: null, sn: null, examples: new Set<string>() };
+      if (sn !== null) acc.sn = sn;
+      if (r.token) acc.token = r.token;
+      if (r.title) acc.examples.add(r.title);
+      accounts.set(key, acc);
+    }
+    return [...accounts.values()]
+      .map((a) => ({ token: a.token, sn: a.sn, examples: [...a.examples] }))
+      .sort((a, b) => (a.sn ?? Infinity) - (b.sn ?? Infinity));
   }
 
-  private async _browseItems(objectId: string): Promise<MediaItem[]> {
-    const player = this.resolveAnyPlayer();
+  private async _browseItems(
+    objectId: string,
+    player: Player = this.resolveAnyPlayer(),
+  ): Promise<MediaItem[]> {
     const res = await player.browse(objectId);
     const didl = decodeEntities(getTagText(res, 'Result') || '');
     const items: MediaItem[] = [];
-    for (const block of [...getTagBlocks(didl, 'item'), ...getTagBlocks(didl, 'container')]) {
+    for (
+      const block of [
+        ...getTagBlocks(didl, 'item'),
+        ...getTagBlocks(didl, 'container'),
+      ]
+    ) {
       const title = getTagText(block, 'dc:title');
       // <res> and <r:resMD> are entity-encoded a second time inside the DIDL.
       const uri = decodeEntities(getTagText(block, 'res') || '');
@@ -136,37 +259,6 @@ export class SonosSystem {
     const baseUrl = first ? first.baseUrl : this._seedBaseUrl!;
     return new Player({ uuid: first?.coordinatorUuid ?? '', baseUrl });
   }
-
-  async playFavorite(coordinator: Player, name: string): Promise<string> {
-    const fav = findByTitle(await this.getFavorites(), name);
-    if (!fav) throw new Error(`Favorite "${name}" not found`);
-    if (isRadio(fav.uri)) {
-      await coordinator.setAVTransport(fav.uri, fav.metadata);
-    } else {
-      await coordinator.clearQueue();
-      await coordinator.addURIToQueue(fav.uri, fav.metadata);
-      await coordinator.setAVTransport(`x-rincon-queue:${coordinator.uuid}#0`);
-    }
-    return coordinator.play();
-  }
-
-  async playPlaylist(coordinator: Player, name: string): Promise<string> {
-    const pl = findByTitle(await this.getPlaylists(), name);
-    if (!pl) throw new Error(`Playlist "${name}" not found`);
-    await coordinator.clearQueue();
-    await coordinator.addURIToQueue(pl.uri, '');
-    await coordinator.setAVTransport(`x-rincon-queue:${coordinator.uuid}#0`);
-    return coordinator.play();
-  }
-}
-
-function findByTitle(items: MediaItem[], name: string): MediaItem | undefined {
-  const n = String(name).toLowerCase();
-  return items.find((i) => i.title.toLowerCase() === n);
-}
-
-function isRadio(uri: string): boolean {
-  return RADIO_PREFIXES.some((p) => uri.startsWith(p));
 }
 
 function locationToBaseUrl(location: string | undefined): string | null {
@@ -175,5 +267,13 @@ function locationToBaseUrl(location: string | undefined): string | null {
     return new URL(location).origin; // http://192.168.0.195:1400
   } catch {
     return null;
+  }
+}
+
+function hostOf(baseUrl: string): string {
+  try {
+    return new URL(baseUrl).hostname;
+  } catch {
+    return baseUrl;
   }
 }

--- a/lib/sonos/xml.ts
+++ b/lib/sonos/xml.ts
@@ -1,9 +1,11 @@
-// Minimal, dependency-free XML helpers for talking to Sonos over SOAP.
-// We only ever build small request bodies and pull a handful of fields out of
-// responses, so hand-rolled entity handling + regex extraction is enough — no
-// XML library required.
+// Small, dependency-free XML helpers for talking to Sonos over SOAP. We only
+// build tiny request bodies and pull a handful of fields out of responses, so
+// hand-rolled entity coding + regex extraction is enough — no XML library, and a
+// regex walk is immune to XXE / entity-expansion attacks on the semi-trusted
+// DIDL we parse.
 
-// Encode a string for safe inclusion in XML text/attributes.
+// Encode a string for safe inclusion in XML text/attributes. `'` becomes the
+// numeric `&#39;` (valid everywhere, unlike the XML-only `&apos;`).
 // Order matters: `&` must be escaped first or it would double-escape the others.
 export function encodeEntities(str: string): string {
   return String(str)
@@ -11,35 +13,40 @@ export function encodeEntities(str: string): string {
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;')
-    .replace(/'/g, '&apos;');
+    .replace(/'/g, '&#39;');
 }
 
-// Decode XML entities, including numeric forms. Sonos sometimes double-encodes
-// nested DIDL (e.g. a Browse <Result>, or a favorite's <r:resMD>), so callers
-// may need to run this twice.
+// Decode XML entities: the five predefined ones, plus every numeric character
+// reference (decimal & hex) — e.g. a track title's `Caf&#233;`/`&#x2014;`. Sonos
+// sometimes double-encodes nested DIDL (a Browse <Result>, a favorite's
+// <r:resMD>), so callers may need to run this twice.
 export function decodeEntities(str: string): string {
   return String(str)
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
     .replace(/&quot;/g, '"')
     .replace(/&apos;/g, "'")
-    .replace(/&#0*39;/g, "'")
-    .replace(/&#x0*27;/gi, "'")
-    .replace(/&#0*34;/g, '"')
+    .replace(/&#(\d+);/g, (_, n) => String.fromCodePoint(Number(n)))
+    .replace(/&#x([0-9a-f]+);/gi, (_, h) => String.fromCodePoint(parseInt(h, 16)))
     .replace(/&amp;/g, '&'); // last, mirror of encode order
 }
 
 // Return the text content of the first <tag>...</tag> (tag may be namespaced,
 // e.g. "dc:title" or "r:resMD"). Returns undefined if absent.
 export function getTagText(xml: string, tag: string): string | undefined {
-  const m = new RegExp(`<${escapeTag(tag)}\\b[^>]*>([\\s\\S]*?)</${escapeTag(tag)}>`).exec(xml);
+  const m = new RegExp(
+    `<${escapeTag(tag)}\\b[^>]*>([\\s\\S]*?)</${escapeTag(tag)}>`,
+  ).exec(xml);
   return m ? m[1] : undefined;
 }
 
 // Return an array of full <tag ...>...</tag> blocks (including self-closing).
 export function getTagBlocks(xml: string, tag: string): string[] {
   const t = escapeTag(tag);
-  const re = new RegExp(`<${t}\\b[^>]*?/>|<${t}\\b[^>]*>[\\s\\S]*?</${t}>`, 'g');
+  const re = new RegExp(
+    `<${t}\\b[^>]*?/>|<${t}\\b[^>]*>[\\s\\S]*?</${t}>`,
+    'g',
+  );
   return xml.match(re) || [];
 }
 

--- a/usersettings.json.example
+++ b/usersettings.json.example
@@ -1,8 +1,0 @@
-{
-  "sonos_room": "Living Room",
-  "sonos_seed_ip": "",
-  "reset_repeat": true,
-  "reset_shuffle": true,
-  "reset_crossfade": true,
-  "min_volume": 10
-}


### PR DESCRIPTION
Reworks tapdeck around a streamlined Spotify-only flow with real setup/diagnostics. Split into focused commits (one logical change each) for review.

## Highlights
- **`spotify_account_sn` + discovery** — pick which linked Spotify account to play from; `getSpotifyAccounts` mines favorites and room queues for the account serials. (Fixes a latent bug: hard-coded `sn=1` was wrong on multi-account systems.)
- **`tapdeck status`** — confirms it can reach Sonos and lists rooms (+IPs) and Spotify accounts. The pre-setup diagnostic.
- **`tapdeck setup`** — interactive: discovers the system, asks room + account, writes `~/.tapdeck/config.json`, offers pm2 autostart. A fresh install with no config runs it automatically.
- **Config at `~/.tapdeck/config.json`** (or cwd `usersettings.json` for dev); defaults + coercion centralized in `resolveSettings`. The bundled example file is removed in favor of `setup` + the README schema.
- **XML decoder fix** — decodes all numeric character references (e.g. `Caf&#233;`), still hand-rolled with **zero runtime dependencies**.
- **Lazy libpcsclite load** so `status`/`setup` run on machines without the reader library.

## ⚠️ Breaking change
`favorite:` and `playlist:` tags are no longer supported — tapdeck is **Spotify-only**. Spotify track/album/playlist URIs, `room:`, and `command:` tags are unchanged.

## Permissions
The binary moves from read-only to also requiring `--allow-write` (setup writes config), `--allow-run=pm2` (optional autostart), and `+HOME` env (config location). Updated in `deno.json` and `release.yml`.

## Commits
1. `style:` deno fmt  2. `chore(editor):` VS Code config  3. `build:` widen perms
4. `feat(config):` settings module  5. `fix(xml):` numeric entities  6. `refactor(nfc):` lazy libpcsclite
7. `feat(spotify):` account selection  8. `feat(sonos):` account discovery + status helpers; drop favorites engine
9. `feat!:` Spotify-only dispatch  10. `feat(pm2):` autostart helper  11. `feat(cli):` status/setup  12. `docs:`

Two commits are file-scoped where one file carries closely-related sub-changes (`system.ts` bundles account-discovery with the favorites-engine removal; `index.ts` bundles status/setup/first-run) — interactive hunk-splitting wasn't available; happy to split further on request.

## Validation
`deno fmt --check`, `deno lint`, `deno check`, `deno task test` (41 passing) all green. `status` verified live against hardware; the interactive `setup`/pm2 path needs a TTY and wasn't exercised end-to-end in CI.